### PR TITLE
Add/makefile for smlnj

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 *.d
 # object
 *.o
-# compilation manager for sml/nj
+# sml/nj
+bin/
 .cm/
 # library
 libsmlunit.poly

--- a/Makefile.smlnj
+++ b/Makefile.smlnj
@@ -23,9 +23,10 @@ PREFIX          ?= /usr/local/sml
 LIBDIR          ?= lib/smlunit-lib.cm
 DOCDIR          ?= doc/smlunit-lib
 
-DEPENDS         := smlunit-lib.d src/test/sources.d example/sources.d
+DEPENDS         := smlunit-lib.d src/test/sources.d basis/test/sources.d example/sources.d
 
 TEST_TARGET     := bin/TestMain.$(HEAP_SUFFIX)
+BASIS_TEST_TARGET := bin/BasisTestMain.$(HEAP_SUFFIX)
 EXAMPLE_TARGET  := bin/ExampleMain.$(HEAP_SUFFIX)
 
 all: smlunit-lib-nodoc
@@ -103,14 +104,15 @@ $(TEST_TARGET): .cm/$(CM_SUFFIX) src/test/sources.cm
 	$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) src/test/sources.cm TestMain.main $(basename $@)
 
 
+$(BASIS_TEST_TARGET): .cm/$(CM_SUFFIX) basis/test/sources.cm
+	@mkdir -p bin
+	$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) basis/test/sources.cm TestMain.main $(basename $@)
+
+
 .PHONY: test
-test: $(TEST_TARGET) $(EXAMPLE_TARGET)
-	$(SML) $(SML_BITMODE) $(SML_DULIST) $(SML_FLAGS) @SMLload=$<
-
-
-.PHONY: test-ignored
-test-ignored: $(TEST_TARGET)
-	$(SML) $(SML_BITMODE) $(SML_DULIST) $(SML_FLAGS) @SMLload=$< --ignored
+test: $(TEST_TARGET) $(BASIS_TEST_TARGET)
+	$(SML) $(SML_BITMODE) $(SML_DULIST) $(SML_FLAGS) @SMLload=$(TEST_TARGET)
+	$(SML) $(SML_BITMODE) $(SML_DULIST) $(SML_FLAGS) @SMLload=$(BASIS_TEST_TARGET)
 
 
 $(EXAMPLE_TARGET): .cm/$(CM_SUFFIX) example/sources.cm
@@ -132,5 +134,7 @@ clean:
 	-$(RM) -r src/main/.cm
 	-$(RM) -r src/test/.cm
 	-$(RM) $(TEST_TARGET)
+	-$(RM) -r basis/test/.cm
+	-$(RM) $(BASIS_TEST_TARGET)
 	-$(RM) -r example/.cm
 	-$(RM) $(EXAMPLE_TARGET)

--- a/Makefile.smlnj
+++ b/Makefile.smlnj
@@ -100,12 +100,12 @@ install-doc: doc
 
 $(TEST_TARGET): src/test/.cm/$(CM_SUFFIX)
 	@mkdir -p bin
-	$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) $(patsubst %/.cm/$(CM_SUFFIX),%/sources.cm,$<) TestMain.main $(basename $@)
+	$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) $(<:%/.cm/$(CM_SUFFIX)=%/sources.cm) TestMain.main $(basename $@)
 
 
 $(BASIS_TEST_TARGET): basis/test/.cm/$(CM_SUFFIX)
 	@mkdir -p bin
-	$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) $(patsubst %/.cm/$(CM_SUFFIX),%/sources.cm,$<) TestMain.main $(basename $@)
+	$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) $(<:%/.cm/$(CM_SUFFIX)=%/sources.cm) TestMain.main $(basename $@)
 
 
 .PHONY: test

--- a/Makefile.smlnj
+++ b/Makefile.smlnj
@@ -58,7 +58,7 @@ $(DEPENDS): %.d: %.cm
 	@sed -i -e "s|^\([^#][^:]\+\):|\1 $@:|" $@
 
 
-ifneq (clean,$(findstring clean,$(MAKECMDGOALS)))
+ifeq (,$(findstring clean,$(MAKECMDGOALS)))
   include $(DEPENDS)
 endif
 

--- a/Makefile.smlnj
+++ b/Makefile.smlnj
@@ -1,35 +1,35 @@
 
-SML             ?= sml
+SML               := sml
 # -32 or -64
 # empty is default
-SML_BITMODE     ?=
-SML_FLAGS       ?=
-HEAP_SUFFIX     ?= $(shell $(SML) $(SML_BITMODE) @SMLsuffix)
+SML_BITMODE       :=
+SML_FLAGS         :=
+HEAP_SUFFIX       := $(shell $(SML) $(SML_BITMODE) @SMLsuffix)
 
 # directory of CM product
-CM_SUFFIX       := $(shell $(SML) $(SML_BITMODE) < script/suffix.sml 2>&1 >/dev/null)
+CM_SUFFIX         := $(shell $(SML) $(SML_BITMODE) < script/suffix.sml 2>&1 >/dev/null)
 
-SMLDOC          ?= smldoc
-SMLDOC_ARGFILE  := src/smldoc.cfg
+SMLDOC            := smldoc
+SMLDOC_ARGFILE    := src/smldoc.cfg
 
-MLBUILD         ?= ml-build
-MLBUILD_FLAGS   ?=
+MLBUILD           := ml-build
+MLBUILD_FLAGS     :=
 
-MLDEPENDS       ?= ml-makedepend
-MLDEPENDS_FLAGS ?= -n
+MLDEPENDS         := ml-makedepend
+MLDEPENDS_FLAGS   := -n
 
-SML_DULIST      ?=
+SML_DULIST        :=
 
-PREFIX          ?= /usr/local/sml
-LIBDIR          ?= lib/smlunit-lib.cm
-DOCDIR          ?= doc/smlunit-lib
+PREFIX            := /usr/local/sml
+LIBDIR            := lib/smlunit-lib.cm
+DOCDIR            := doc/smlunit-lib
 
-SOURCES_CM      := smlunit-lib.cm \
-                   src/test/sources.cm \
-                   basis/test/sources.cm \
-                   example/sources.cm
+SOURCES_CM        := smlunit-lib.cm \
+                     src/test/sources.cm \
+                     basis/test/sources.cm \
+                     example/sources.cm
 
-DEPENDS         := $(SOURCES_CM:.cm=.d)
+DEPENDS           := $(SOURCES_CM:.cm=.d)
 
 TEST_TARGET       := bin/TestMain.$(HEAP_SUFFIX)
 BASIS_TEST_TARGET := bin/BasisTestMain.$(HEAP_SUFFIX)

--- a/Makefile.smlnj
+++ b/Makefile.smlnj
@@ -20,9 +20,10 @@ PREFIX          ?= /usr/local/sml
 LIBDIR          ?= lib/smlunit-lib.cm
 DOCDIR          ?= doc/smlunit-lib
 
-DEPENDS         := smlunit-lib.d src/test/sources.d
+DEPENDS         := smlunit-lib.d src/test/sources.d example/sources.d
 
-TEST_TARGET     ?= bin/TestMain.$(HEAP_SUFFIX)
+TEST_TARGET     := bin/TestMain.$(HEAP_SUFFIX)
+EXAMPLE_TARGET  := bin/ExampleMain.$(HEAP_SUFFIX)
 
 all: smlunit-lib-nodoc
 
@@ -32,10 +33,10 @@ smlunit-lib-nodoc: .cm/$(HEAP_SUFFIX)
 
 
 .PHONY: smlunit-lib
-smlunit-lib: .cm/$(HEAP_SUFFIX) doc
+smlunit-lib: smlunit-lib-nodoc doc
 
 
-.cm/$(HEAP_SUFFIX): smlunit-lib.d smlunit-lib.cm
+.cm/$(HEAP_SUFFIX): smlunit-lib.cm
 	@echo "  [SMLNJ] $@"
 	@echo 'CM.stabilize true "smlunit-lib.cm";' | $(SML) $(SML_BITMODE) $(SML_DULIST)
 
@@ -46,13 +47,22 @@ $(DEPENDS): %.d: %.cm
 	$(MLDEPENDS) $(MLDEPENDS_FLAGS) $(SML_BITMODE) $(SML_DULIST) -f $@ $< $(dir $<).cm/$(HEAP_SUFFIX)
 	@sed -i -e "s|^\([^#][^:]\+\):|\1 $@:|" $@
 
+
 ifeq (,$(findstring $(MAKECMDGOALS),clean))
   include smlunit-lib.d
 endif
 
+
 ifeq ($(MAKECMDGOALS),test)
   include src/test/sources.d
+  include example/sources.d
 endif
+
+
+ifeq ($(MAKECMDGOALS),example)
+  include example/sources.d
+endif
+
 
 .PHONY: install-nodoc
 install-nodoc: smlunit-lib-nodoc
@@ -101,7 +111,7 @@ $(TEST_TARGET): smlunit-lib-nodoc src/test/sources.cm
 
 
 .PHONY: test
-test: $(TEST_TARGET)
+test: $(TEST_TARGET) $(EXAMPLE_TARGET)
 	$(SML) $(SML_BITMODE) $(SML_DULIST) $(SML_FLAGS) @SMLload=$<
 
 
@@ -110,13 +120,24 @@ test-ignored: $(TEST_TARGET)
 	$(SML) $(SML_BITMODE) $(SML_DULIST) $(SML_FLAGS) @SMLload=$< --ignored
 
 
+$(EXAMPLE_TARGET): smlunit-lib-nodoc example/sources.cm
+	@mkdir -p bin
+	$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) example/sources.cm Main.main $@
+
+
+.PHONY: example
+example: $(EXAMPLE_TARGET)
+	$(SML) $(SML_BITMODE) $(SML_DULIST) $(SML_FLAGS) @SMLload=$<
+
+
 .PHONY: clean
 clean:
 	-$(RM) $(DEPENDS)
 	-$(RM) -r doc
-	-$(RM) $(TEST_TARGET)
 	-$(RM) -r .cm
 	-$(RM) -r src/.cm
 	-$(RM) -r src/main/.cm
 	-$(RM) -r src/test/.cm
-
+	-$(RM) $(TEST_TARGET)
+	-$(RM) -r example/.cm
+	-$(RM) $(EXAMPLE_TARGET)

--- a/Makefile.smlnj
+++ b/Makefile.smlnj
@@ -23,11 +23,16 @@ PREFIX          ?= /usr/local/sml
 LIBDIR          ?= lib/smlunit-lib.cm
 DOCDIR          ?= doc/smlunit-lib
 
-DEPENDS         := smlunit-lib.d src/test/sources.d basis/test/sources.d example/sources.d
+SOURCES_CM      := smlunit-lib.cm \
+                   src/test/sources.cm \
+                   basis/test/sources.cm \
+                   example/sources.cm
 
-TEST_TARGET     := bin/TestMain.$(HEAP_SUFFIX)
+DEPENDS         := $(SOURCES_CM:.cm=.d)
+
+TEST_TARGET       := bin/TestMain.$(HEAP_SUFFIX)
 BASIS_TEST_TARGET := bin/BasisTestMain.$(HEAP_SUFFIX)
-EXAMPLE_TARGET  := bin/ExampleMain.$(HEAP_SUFFIX)
+EXAMPLE_TARGET    := bin/ExampleMain.$(HEAP_SUFFIX)
 
 all: smlunit-lib-nodoc
 
@@ -53,9 +58,7 @@ $(DEPENDS): %.d: %.cm
 
 
 ifneq (clean,$(findstring clean,$(MAKECMDGOALS)))
-  include smlunit-lib.d
-  include src/test/sources.d
-  include example/sources.d
+  include $(DEPENDS)
 endif
 
 .PHONY: install-nodoc

--- a/Makefile.smlnj
+++ b/Makefile.smlnj
@@ -68,10 +68,10 @@ install-nodoc: smlunit-lib-nodoc
 	@echo "================================================================"
 	@echo "smlunit-lib has been installed to:"
 	@echo "\t$(PREFIX)/$(LIBDIR)"
-	@echo "Add an entry to your pathconfig (e.g. ~/.smlnj-pathconfig) such like:"
+	@echo "Next, add an entry to your pathconfig (e.g. ~/.smlnj-pathconfig) such like:"
 	@echo "\tsmlunit-lib.cm $(PREFIX)/$(LIBDIR)"
 	@echo "Then you can load the library like"
-	@echo "\t\"CM.make \"$$/smlunit-lib.cm\";\"."
+	@echo "\t- CM.make \"$$/smlunit-lib.cm\";"
 	@echo "================================================================"
 
 

--- a/Makefile.smlnj
+++ b/Makefile.smlnj
@@ -10,6 +10,7 @@ HEAP_SUFFIX     ?= $(shell $(SML) $(SML_BITMODE) @SMLsuffix)
 CM_SUFFIX       := $(shell $(SML) $(SML_BITMODE) < script/suffix.sml 2>&1 >/dev/null)
 
 SMLDOC          ?= smldoc
+SMLDOC_ARGFILE  := src/smldoc.cfg
 
 MLBUILD         ?= ml-build
 MLBUILD_FLAGS   ?=
@@ -81,21 +82,16 @@ install: install-doc install-nodoc
 
 .PHONY: doc
 doc:
-	@echo "  [SMLDoc] $@"
-	@$(RM) -r doc
-	@mkdir doc
-	@$(SMLDOC) -c UTF-8 \
-		--hidebysig \
-		--recursive \
-		--linksource \
-		-d doc \
-		smlunit-lib.cm
+	@echo "  [SMLDoc]"
+	@$(RM) -r $(DOCDIR)
+	@install -d $(DOCDIR)
+	@$(SMLDOC) -c UTF-8 -a $(SMLDOC_ARGFILE) -d "$(DOCDIR)"
 
 
 .PHONY: install-doc
 install-doc: doc
 	@install -d $(PREFIX)/$(DOCDIR)
-	@cp -prT doc $(PREFIX)/$(DOCDIR)
+	@cp -prT $(DOCDIR) $(PREFIX)/$(DOCDIR)
 	@echo "================================================================"
 	@echo "Generated API Documents of SMLUnit"
 	@echo "\t$(PREFIX)/$(DOCDIR)"
@@ -131,7 +127,7 @@ example: $(EXAMPLE_TARGET)
 .PHONY: clean
 clean:
 	-$(RM) $(DEPENDS)
-	-$(RM) -r doc
+	-$(RM) -r $(DOCDIR)
 	-$(RM) -r .cm
 	-$(RM) -r src/.cm
 	-$(RM) -r src/main/.cm

--- a/Makefile.smlnj
+++ b/Makefile.smlnj
@@ -34,7 +34,7 @@ TEST_TARGET       := bin/TestMain.$(HEAP_SUFFIX)
 BASIS_TEST_TARGET := bin/BasisTestMain.$(HEAP_SUFFIX)
 EXAMPLE_TARGET    := bin/ExampleMain.$(HEAP_SUFFIX)
 
-all: smlunit-lib-nodoc
+all: smlunit-lib
 
 
 .PHONY: smlunit-lib-nodoc

--- a/Makefile.smlnj
+++ b/Makefile.smlnj
@@ -1,0 +1,122 @@
+
+SML             ?= sml
+# -32 or -64
+# empty is default
+SML_BITMODE     ?=
+SML_FLAGS       ?=
+HEAP_SUFFIX     ?= $(shell $(SML) $(SML_BITMODE) @SMLsuffix)
+
+SMLDOC          ?= smldoc
+
+MLBUILD         ?= ml-build
+MLBUILD_FLAGS   ?=
+
+MLDEPENDS       ?= ml-makedepend
+MLDEPENDS_FLAGS ?= -n
+
+SML_DULIST      ?=
+
+PREFIX          ?= /usr/local/sml
+LIBDIR          ?= lib/smlunit-lib.cm
+DOCDIR          ?= doc/smlunit-lib
+
+DEPENDS         := smlunit-lib.d src/test/sources.d
+
+TEST_TARGET     ?= bin/TestMain.$(HEAP_SUFFIX)
+
+all: smlunit-lib-nodoc
+
+
+.PHONY: smlunit-lib-nodoc
+smlunit-lib-nodoc: .cm/$(HEAP_SUFFIX)
+
+
+.PHONY: smlunit-lib
+smlunit-lib: .cm/$(HEAP_SUFFIX) doc
+
+
+.cm/$(HEAP_SUFFIX): smlunit-lib.d smlunit-lib.cm
+	@echo "  [SMLNJ] $@"
+	@echo 'CM.stabilize true "smlunit-lib.cm";' | $(SML) $(SML_BITMODE) $(SML_DULIST)
+
+
+$(DEPENDS): %.d: %.cm
+	@echo "  [GEN] $@"
+	@touch $@
+	$(MLDEPENDS) $(MLDEPENDS_FLAGS) $(SML_BITMODE) $(SML_DULIST) -f $@ $< $(dir $<).cm/$(HEAP_SUFFIX)
+	@sed -i -e "s|^\([^#][^:]\+\):|\1 $@:|" $@
+
+ifeq (,$(findstring $(MAKECMDGOALS),clean))
+  include smlunit-lib.d
+endif
+
+ifeq ($(MAKECMDGOALS),test)
+  include src/test/sources.d
+endif
+
+.PHONY: install-nodoc
+install-nodoc: smlunit-lib-nodoc
+	@install -d $(PREFIX)/$(LIBDIR)
+	@cp -R .cm $(PREFIX)/$(LIBDIR)/
+	@echo "================================================================"
+	@echo "smlunit-lib has been installed to:"
+	@echo "\t$(PREFIX)/$(LIBDIR)"
+	@echo "Add an entry to your pathconfig (e.g. ~/.smlnj-pathconfig) such like:"
+	@echo "\tsmlunit-lib.cm $(PREFIX)/$(LIBDIR)"
+	@echo "Then you can load the library like"
+	@echo "\t\"CM.make \"$$/smlunit-lib.cm\";\"."
+	@echo "================================================================"
+
+
+.PHONY: install
+install: install-nodoc install-doc
+
+
+.PHONY: doc
+doc:
+	@echo "  [SMLDoc] $@"
+	@$(RM) -r doc
+	@mkdir doc
+	@$(SMLDOC) -c UTF-8 \
+		--hidebysig \
+		--recursive \
+		--linksource \
+		-d doc \
+		smlunit-lib.cm
+
+
+.PHONY: install-doc
+install-doc: doc
+	@install -d $(PREFIX)/$(DOCDIR)
+	@cp -prT doc $(PREFIX)/$(DOCDIR)
+	@echo "================================================================"
+	@echo "Generated API Documents of SMLUnit"
+	@echo "\t$(PREFIX)/$(DOCDIR)"
+	@echo "================================================================"
+
+
+$(TEST_TARGET): smlunit-lib-nodoc src/test/sources.cm
+	@mkdir -p bin
+	$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) src/test/sources.cm TestMain.test $@
+
+
+.PHONY: test
+test: $(TEST_TARGET)
+	$(SML) $(SML_BITMODE) $(SML_DULIST) $(SML_FLAGS) @SMLload=$<
+
+
+.PHONY: test-ignored
+test-ignored: $(TEST_TARGET)
+	$(SML) $(SML_BITMODE) $(SML_DULIST) $(SML_FLAGS) @SMLload=$< --ignored
+
+
+.PHONY: clean
+clean:
+	-$(RM) $(DEPENDS)
+	-$(RM) -r doc
+	-$(RM) $(TEST_TARGET)
+	-$(RM) -r .cm
+	-$(RM) -r src/.cm
+	-$(RM) -r src/main/.cm
+	-$(RM) -r src/test/.cm
+

--- a/Makefile.smlnj
+++ b/Makefile.smlnj
@@ -97,7 +97,7 @@ install-doc: doc
 
 $(TEST_TARGET): smlunit-lib-nodoc src/test/sources.cm
 	@mkdir -p bin
-	$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) src/test/sources.cm TestMain.test $@
+	$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) src/test/sources.cm TestMain.main $@
 
 
 .PHONY: test

--- a/Makefile.smlnj
+++ b/Makefile.smlnj
@@ -6,6 +6,9 @@ SML_BITMODE     ?=
 SML_FLAGS       ?=
 HEAP_SUFFIX     ?= $(shell $(SML) $(SML_BITMODE) @SMLsuffix)
 
+# directory of CM product
+CM_SUFFIX       := $(shell $(SML) $(SML_BITMODE) < script/suffix.sml 2>&1 >/dev/null)
+
 SMLDOC          ?= smldoc
 
 MLBUILD         ?= ml-build
@@ -29,14 +32,14 @@ all: smlunit-lib-nodoc
 
 
 .PHONY: smlunit-lib-nodoc
-smlunit-lib-nodoc: .cm/$(HEAP_SUFFIX)
+smlunit-lib-nodoc: .cm/$(CM_SUFFIX)
 
 
 .PHONY: smlunit-lib
 smlunit-lib: smlunit-lib-nodoc doc
 
 
-.cm/$(HEAP_SUFFIX): smlunit-lib.cm
+.cm/$(CM_SUFFIX): smlunit-lib.cm
 	@echo "  [SMLNJ] $@"
 	@echo 'CM.stabilize true "smlunit-lib.cm";' | $(SML) $(SML_BITMODE) $(SML_DULIST)
 
@@ -44,25 +47,15 @@ smlunit-lib: smlunit-lib-nodoc doc
 $(DEPENDS): %.d: %.cm
 	@echo "  [GEN] $@"
 	@touch $@
-	$(MLDEPENDS) $(MLDEPENDS_FLAGS) $(SML_BITMODE) $(SML_DULIST) -f $@ $< $(dir $<).cm/$(HEAP_SUFFIX)
+	$(MLDEPENDS) $(MLDEPENDS_FLAGS) $(SML_BITMODE) $(SML_DULIST) -f $@ $< $(dir $<).cm/$(CM_SUFFIX)
 	@sed -i -e "s|^\([^#][^:]\+\):|\1 $@:|" $@
 
 
-ifeq (,$(findstring $(MAKECMDGOALS),clean))
+ifneq (clean,$(findstring clean,$(MAKECMDGOALS)))
   include smlunit-lib.d
-endif
-
-
-ifeq ($(MAKECMDGOALS),test)
   include src/test/sources.d
   include example/sources.d
 endif
-
-
-ifeq ($(MAKECMDGOALS),example)
-  include example/sources.d
-endif
-
 
 .PHONY: install-nodoc
 install-nodoc: smlunit-lib-nodoc
@@ -105,9 +98,9 @@ install-doc: doc
 	@echo "================================================================"
 
 
-$(TEST_TARGET): smlunit-lib-nodoc src/test/sources.cm
+$(TEST_TARGET): .cm/$(CM_SUFFIX) src/test/sources.cm
 	@mkdir -p bin
-	$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) src/test/sources.cm TestMain.main $@
+	$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) src/test/sources.cm TestMain.main $(basename $@)
 
 
 .PHONY: test
@@ -120,9 +113,9 @@ test-ignored: $(TEST_TARGET)
 	$(SML) $(SML_BITMODE) $(SML_DULIST) $(SML_FLAGS) @SMLload=$< --ignored
 
 
-$(EXAMPLE_TARGET): smlunit-lib-nodoc example/sources.cm
+$(EXAMPLE_TARGET): .cm/$(CM_SUFFIX) example/sources.cm
 	@mkdir -p bin
-	$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) example/sources.cm Main.main $@
+	$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) example/sources.cm Main.main $(basename $@)
 
 
 .PHONY: example

--- a/Makefile.smlnj
+++ b/Makefile.smlnj
@@ -33,16 +33,16 @@ all: smlunit-lib-nodoc
 
 
 .PHONY: smlunit-lib-nodoc
-smlunit-lib-nodoc: .cm/$(CM_SUFFIX)
+smlunit-lib-nodoc: .cm/$(CM_SUFFIX)/smlunit-lib.cm
 
 
 .PHONY: smlunit-lib
 smlunit-lib: smlunit-lib-nodoc doc
 
 
-.cm/$(CM_SUFFIX): smlunit-lib.cm
+.cm/$(CM_SUFFIX)/%.cm: %.cm
 	@echo "  [SMLNJ] $@"
-	@echo 'CM.stabilize true "smlunit-lib.cm";' | $(SML) $(SML_BITMODE) $(SML_DULIST)
+	@echo 'CM.stabilize true "$<";' | $(SML) $(SML_BITMODE) $(SML_DULIST)
 
 
 $(DEPENDS): %.d: %.cm
@@ -73,7 +73,7 @@ install-nodoc: smlunit-lib-nodoc
 
 
 .PHONY: install
-install: install-nodoc install-doc
+install: install-doc install-nodoc
 
 
 .PHONY: doc
@@ -99,14 +99,14 @@ install-doc: doc
 	@echo "================================================================"
 
 
-$(TEST_TARGET): .cm/$(CM_SUFFIX) src/test/sources.cm
+$(TEST_TARGET): src/test/.cm/$(CM_SUFFIX)
 	@mkdir -p bin
-	$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) src/test/sources.cm TestMain.main $(basename $@)
+	$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) $(patsubst %/.cm/$(CM_SUFFIX),%/sources.cm,$<) TestMain.main $(basename $@)
 
 
-$(BASIS_TEST_TARGET): .cm/$(CM_SUFFIX) basis/test/sources.cm
+$(BASIS_TEST_TARGET): basis/test/.cm/$(CM_SUFFIX)
 	@mkdir -p bin
-	$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) basis/test/sources.cm TestMain.main $(basename $@)
+	$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) $(patsubst %/.cm/$(CM_SUFFIX),%/sources.cm,$<) TestMain.main $(basename $@)
 
 
 .PHONY: test
@@ -115,9 +115,9 @@ test: $(TEST_TARGET) $(BASIS_TEST_TARGET)
 	$(SML) $(SML_BITMODE) $(SML_DULIST) $(SML_FLAGS) @SMLload=$(BASIS_TEST_TARGET)
 
 
-$(EXAMPLE_TARGET): .cm/$(CM_SUFFIX) example/sources.cm
+$(EXAMPLE_TARGET): example/.cm/$(CM_SUFFIX)
 	@mkdir -p bin
-	$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) example/sources.cm Main.main $(basename $@)
+	$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) $(patsubst %/.cm/amd64-unix,%/sources.cm,$<) Main.main $(basename $@)
 
 
 .PHONY: example

--- a/basis/test/TestMain.sml
+++ b/basis/test/TestMain.sml
@@ -10,13 +10,17 @@ struct
   local
     open SMLUnit.Test
   in
-  fun test () =
+  fun main (_: string, _: string list) =
       let
         val tests =
             TestList
                 (TestRequiredModules.tests () @ TestOptionalModules.tests ())
       in SMLUnit.TextUITestRunner.runTest {output = TextIO.stdOut} tests
+       ; OS.Process.success
       end
   end
+
+  fun test () =
+    ignore (main (CommandLine.name(), CommandLine.arguments()))
 
 end

--- a/example/ml_bind.sml
+++ b/example/ml_bind.sml
@@ -1,4 +1,2 @@
 
 structure Main = Main
-
-

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ When the execution of the `install` or `install-nodoc` target is completed, add 
 $ echo 'smlunit-lib.cm /usr/local/smlnj/lib/smlunit-lib.cm'
 ```
 
-Or
+or
 
 ```sh
 $ echo 'smlunit-lib.cm PREFIX/lib/smlunit-lib.cm'

--- a/readme.md
+++ b/readme.md
@@ -75,14 +75,14 @@ To specify destination directory, run make with the variable `PREFIX`:
 $ make -f Makefile.smlnj install PREFIX=~/.sml/smlnj
 ```
 
-The `install` target use `SMLDoc` to generate the documentations of SMLUnit.
+The `install` target uses `SMLDoc` to generate the documentations of SMLUnit.
 If you do not need to generate documentation, run the `install-nodoc` target.
 
 ```sh
 $ make -f Makefile.smlnj install-nodoc
 ```
 
-When the execution of the `install` or `install-nodoc` target is completed, add an entry for `smlunit-lib.cm` to the pathconfig file and the installation is complete.
+After execution `install` or `install-nodoc` target, add an entry for `smlunit-lib.cm` to the pathconfig file to complete the installation.
 
 ```sh
 $ echo 'smlunit-lib.cm /usr/local/smlnj/lib/smlunit-lib.cm'

--- a/readme.md
+++ b/readme.md
@@ -63,35 +63,55 @@ $ smlsharp -I/path/to/smlunit -L/path/to/smlunit -o test_foo test_foo.smi
 
 #### Install
 
-To install SMLUnit for SML/NJ, run `make install` using `Makefile.smlnj`:
+To install SMLUnit for SML/NJ, run `make install` with `Makefile.smlnj`:
 
 ```sh
 $ make -f Makefile.smlnj install
 ```
 
-To specify destination directory, run make with the variable `PREFIX`:
+To specify the directory to install to, run `make` with the variable `PREFIX`:
 
 ```sh
 $ make -f Makefile.smlnj install PREFIX=~/.sml/smlnj
 ```
 
-The `install` target uses `SMLDoc` to generate the documentations of SMLUnit.
+The `install` target uses `SMLDoc` to generate the documentations for SMLUnit.
 If you do not need to generate documentation, run the `install-nodoc` target.
 
 ```sh
 $ make -f Makefile.smlnj install-nodoc
 ```
 
-After execution `install` or `install-nodoc` target, add an entry for `smlunit-lib.cm` to the pathconfig file to complete the installation.
+After running the `install` or `install-nodoc` target, add an entry for `smlunit-lib.cm` to the pathconfig file to complete the installation.
 
 ```sh
-$ echo 'smlunit-lib.cm /usr/local/smlnj/lib/smlunit-lib.cm'
+$ echo 'smlunit-lib.cm /usr/local/smlnj/lib/smlunit-lib.cm' >> ~/.smlnj-pathconfig
 ```
 
 or
 
 ```sh
-$ echo 'smlunit-lib.cm PREFIX/lib/smlunit-lib.cm'
+$ echo 'smlunit-lib.cm PREFIX/lib/smlunit-lib.cm' >> ~/.smlnj-pathconfig
+```
+
+
+#### Test
+
+To run SMLUnit unit tests, run the `test` target:
+
+```sh
+$ make -f Makefile.smlnj test
+```
+
+Depending on the test case, it will fails.
+
+
+#### Examples
+
+To run the example program, run `example` target:
+
+```sh
+$ make -f Makefile.smlnj example
 ```
 
 
@@ -99,7 +119,7 @@ $ echo 'smlunit-lib.cm PREFIX/lib/smlunit-lib.cm'
 
 #### Install
 
-To install SMLUnit for MLton, run `make install` using `Makefile.mlton`:
+To install SMLUnit for MLton, run `make install` with `Makefile.mlton`:
 
 ```sh
 $ make -f Makefile.mlton install
@@ -112,7 +132,7 @@ This install location can be set with `PREFIX` variable.
 $ make -f Makefile.mlton PREFIX=~/.sml/mlton install
 ```
 
-After `make install`, you need to add an entry in your mlb path mapping file:
+After running the `install` target, add an entry for `SMLUNIT_LIB` to your mlb path mapping file:
 
 ```sh
 $ echo 'SMLUNIT_LIB /path/to/$PREFIX' >> /path/to/mlb-path-map
@@ -130,37 +150,21 @@ $(SMLUNIT_LIB)/smlunit-lib.mlb
 
 #### Test
 
-Perform unit tests for SMLUnit, execute `test` target:
+To run SMLUnit unit test, run the `test` target:
 
 ```sh
 $ make -f Makefile.mlton test
 ```
 
-In some test cases, it will fails.
+Depending on the test case, it will fails.
 
 
 #### Examples
 
-This directory contains an example project to `example/`.
-
-`Makefile.mlton` have target `example` build the project.
-And the target is required by default target `all`.
-
+To run the example program, run `example` target:
 
 ```sh
-$ make -f Makefile.mlton
-.
-.
-  [MLTON] example/sources
-$ ./example/sources
-.....
-tests = 5, failures = 0, errors = 0
-Failures:
-Errors:
-.....
-tests = 5, failures = 0, errors = 0
-Failures:
-Errors:
+$ make -f Makefile.smlnj example
 ```
 
 
@@ -194,7 +198,7 @@ val it = (): unit
 
 #### Test
 
-Perform unit tests for SMLUnit, execute `test` target:
+Execute unit tests for SMLUnit, run `test` target:
 
 ```sh
 $ make -f Makefile.polyml test
@@ -221,8 +225,7 @@ install -D -m 644 -t /home/<user>/.sml/polyml/lib libsmlunit.poly
 
 #### Examples
 
-To perform examples with Poly/ML, build target `example` of `Makefile.polyml`.
-
+To run examples with Poly/ML, run the `example` target:
 
 ```sh
 

--- a/readme.md
+++ b/readme.md
@@ -61,25 +61,37 @@ $ smlsharp -I/path/to/smlunit -L/path/to/smlunit -o test_foo test_foo.smi
 
 ### SML/NJ
 
-Compile with `CM` like below:
+#### Install
+
+To install SMLUnit for SML/NJ, run `make install` using `Makefile.smlnj`:
 
 ```sh
-$ LOCAL_LIB=~/.smlnj/lib
-$ mkdir -p $LOCAL_LIB
-$ echo 'CM.stabilize true "smlunit-lib.cm";' | sml
-$ echo "smlunit-lib.cm $LOCAL_LIB/smlunit-lib.cm" >> ~/.smlnj-pathconfig
-$ mkdir -p $LOCAL_LIB/smlunit-lib.cm
-$ cp -R .cm $LOCAL_LIB/smlunit-lib.cm/.cm
+$ make -f Makefile.smlnj install
 ```
 
-Refer to `$/smlunit-lib.cm` from your `sources.cm`.
+To specify destination directory, run make with the variable `PREFIX`:
 
+```sh
+$ make -f Makefile.smlnj install PREFIX=~/.sml/smlnj
 ```
-library
-is
-  $/basis.cm
-  $/smlunit-lib.cm
-  foo_test.sml
+
+The `install` target use `SMLDoc` to generate the documentations of SMLUnit.
+If you do not need to generate documentation, run the `install-nodoc` target.
+
+```sh
+$ make -f Makefile.smlnj install-nodoc
+```
+
+When the execution of the `install` or `install-nodoc` target is completed, add an entry for `smlunit-lib.cm` to the pathconfig file and the installation is complete.
+
+```sh
+$ echo 'smlunit-lib.cm /usr/local/smlnj/lib/smlunit-lib.cm'
+```
+
+Or
+
+```sh
+$ echo 'smlunit-lib.cm PREFIX/lib/smlunit-lib.cm'
 ```
 
 
@@ -87,9 +99,7 @@ is
 
 #### Install
 
-There is a `Makefile.mlton` for MLton.
-
-To install SMLUnit, `make install` with the file:
+To install SMLUnit for MLton, run `make install` using `Makefile.mlton`:
 
 ```sh
 $ make -f Makefile.mlton install

--- a/script/suffix.sml
+++ b/script/suffix.sml
@@ -1,0 +1,15 @@
+
+local
+  structure Sys = SMLofNJ.SysInfo
+in
+fun cmLibDirName () = let
+  val arch = String.map Char.toLower (Sys.getArchName())
+  val opsys =
+    case Sys.getOSKind()
+      of Sys.UNIX => "unix"
+       | Sys.WIN32 => "win32"
+in
+  arch ^ "-" ^ opsys
+end
+val () = TextIO.output(TextIO.stdErr, cmLibDirName())
+end (* local *)

--- a/src/smldoc.cfg
+++ b/src/smldoc.cfg
@@ -1,4 +1,4 @@
---directory=../doc/api/
+--directory=../doc/smlunit-lib
 --hidebysig
 --verbose
 --author

--- a/src/test/Main.sml
+++ b/src/test/Main.sml
@@ -1,2 +1,2 @@
-val _ = TestMain.test()
+val _ = TestMain.test(CommandLine.name(), CommandLine.arguments())
 val () = OS.Process.exit OS.Process.success

--- a/src/test/Main.sml
+++ b/src/test/Main.sml
@@ -1,2 +1,2 @@
-val _ = TestMain.test(CommandLine.name(), CommandLine.arguments())
+val _ = TestMain.test()
 val () = OS.Process.exit OS.Process.success

--- a/src/test/TestMain.sml
+++ b/src/test/TestMain.sml
@@ -5,11 +5,12 @@
 structure TestMain =
 struct
 
-  fun test () =
+  fun test (name, args) =
       (
         TestAssert.runTest ();
         TestTest.runTest ();
-        TestTextUITestRunner.runTest ()
+        TestTextUITestRunner.runTest ();
+        OS.Process.success
       )
 
 end

--- a/src/test/TestMain.sml
+++ b/src/test/TestMain.sml
@@ -5,12 +5,15 @@
 structure TestMain =
 struct
 
-  fun test (name, args) =
+  fun main (name, args) =
       (
         TestAssert.runTest ();
         TestTest.runTest ();
         TestTextUITestRunner.runTest ();
         OS.Process.success
       )
+
+  fun test () =
+    ignore (main (CommandLine.name(), CommandLine.arguments()))
 
 end


### PR DESCRIPTION
Add Makefile for SML/NJ.
The file `Makefile.smlnj` provides following targets:

- `smlunit-lib`, `smlunit-lib-nodoc`
  Build the library.
- `install` and `install-nodoc`
  Install the library.
- `doc`
  Generate documentation to ./doc.
- `test` and `example`
  Build and execute sample programs.
- `clean`
  Delete intermediate files.