### PR TITLE
Improve makefile for mlton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 # sml/nj
 bin/
 .cm/
+# mlton
+bin/.smlunit-lib
 # library
 libsmlunit.poly
 # test executable

--- a/Makefile.mlton
+++ b/Makefile.mlton
@@ -38,7 +38,8 @@ smlunit-lib: smlunit-lib-nodoc doc
 
 $(TYPECHECK_DUMMY): smlunit-lib.mlb
 	@echo "  [MLTON] $@"
-	@$(MLTON) $(MLTON_FLAGS) -output $@ $<
+	@$(MLTON) $(MLTON_FLAGS) -stop tc $<
+	@touch $@
 
 
 smlunit-lib.mlb.d: smlunit-lib.mlb

--- a/Makefile.mlton
+++ b/Makefile.mlton
@@ -2,25 +2,25 @@
 MLTON               := mlton
 MLTON_FLAGS         := -default-ann "nonexhaustiveMatch ignore"
 
-PREFIX              ?= /usr/local/mlton
-LIBDIR              ?= lib/SMLUnit
-DOCDIR              ?= doc/smlunit-lib
+PREFIX              := /usr/local/mlton
+LIBDIR              := lib/SMLUnit
+DOCDIR              := doc/smlunit-lib
 
-SMLDOC              ?= smldoc
+SMLDOC              := smldoc
 SMLDOC_ARGFILE      := src/smldoc.cfg
 
 TYPECHECK_DUMMY     := bin/.smlunit-lib
 
-SMLUNITLIB_TEST_MLB := basis/test/sources.mlb
+TEST_MLB            := src/test/sources.mlb \
+                       basis/test/sources.mlb
+
+EXAMPLE_MLB         := example/sources.mlb
+
 SMLUNIT_MLBS        := smlunit-lib.mlb \
-                       $(SMLUNITLIB_TEST_MLB)
+                       $(TEST_MLB) \
+                       $(EXAMPLE_MLB)
 
-EXAMPLES            := example/sources
-
-EXAMPLE_MLB         := $(EXAMPLES:=.mlb)
-
-DEPENDS             := $(SMLUNIT_MLBS:.mlb=.mlb.d) \
-                       $(EXAMPLE_MLB:.mlb=.mlb.d)
+DEPENDS             := $(SMLUNIT_MLBS:.mlb=.mlb.d)
 
 SMLUNIT_LIB_DIR     := $(shell readlink -f .)
 
@@ -101,21 +101,24 @@ install-doc: doc
 
 
 $(EXAMPLE_MLB:.mlb=): MLTON_FLAGS += -mlb-path-var "SMLUNIT_LIB $(SMLUNIT_LIB_DIR)"
-$(SMLUNITLIB_TEST_MLB:.mlb=) $(EXAMPLE_MLB:.mlb=): %: %.mlb
+$(TEST_MLB:.mlb=) $(EXAMPLE_MLB:.mlb=): %: %.mlb
 	@echo "  [MLTON] $@"
 	@$(MLTON) $(MLTON_FLAGS) -output $@ $<
 
 
 .PHONY: test
-test: $(SMLUNITLIB_TEST_MLB:.mlb=)
-	$(SMLUNITLIB_TEST_MLB:.mlb=)
+test: $(TEST_MLB:.mlb=)
+	@for exe in $^;do \
+		echo "$${exe}" ; \
+		$${exe} ; \
+	done
 
 
 .PHONY: example
-example: $(EXAMPLES)
-	@for ex in $(EXAMPLES);do \
-		echo "$${ex}" ; \
-		$${ex}; \
+example: $(EXAMPLE_MLB:.mlb=)
+	@for exe in $^;do \
+		echo "$${exe}" ; \
+		$${exe} ; \
 	done
 
 
@@ -124,6 +127,5 @@ clean:
 	-$(RM) $(TYPECHECK_DUMMY)
 	-$(RM) -r $(DOCDIR)
 	-$(RM) $(DEPENDS)
-	-$(RM) $(SMLUNIT_MLBS:.mlb=)
-	-$(RM) $(EXAMPLES)
+	-$(RM) $(filter-out smlunit-lib,$(SMLUNIT_MLBS:.mlb=))
 

--- a/Makefile.mlton
+++ b/Makefile.mlton
@@ -14,6 +14,9 @@ SMLUNITLIB_TEST_MLB := basis/test/sources.mlb
 SMLUNIT_MLBS        := $(SMLUNITLIB_MLB)      \
                        $(SMLUNITLIB_TEST_MLB)
 
+DEPENDS             := $(SMLUNIT_MLBS:.mlb=.mlb.d) \
+                       $(EXAMPLE_MLB:.mlb=.mlb.d)
+
 EXAMPLES            := example/sources
 
 EXAMPLE_MLB         := $(EXAMPLES:=.mlb)
@@ -54,8 +57,7 @@ example: typecheck_smlunitlib $(EXAMPLES)
 
 
 ifeq ($(findstring clean,$(MAKECMDGOALS)),)
-include $(SMLUNIT_MLBS:.mlb=.mlb.d)
-include $(EXAMPLE_MLB:.mlb=.mlb.d)
+  include $(DEPENDS)
 endif
 
 
@@ -101,8 +103,7 @@ install-doc: doc
 .PHONY: clean
 clean:
 	-$(RM) -r $(DOCDIR)
+	-$(RM) $(DEPENDS)
 	-$(RM) $(SMLUNIT_MLBS:.mlb=)
-	-$(RM) $(SMLUNIT_MLBS:.mlb=.mlb.d)
 	-$(RM) $(EXAMPLES)
-	-$(RM) $(EXAMPLE_MLB:.mlb=.mlb.d)
 

--- a/Makefile.mlton
+++ b/Makefile.mlton
@@ -1,8 +1,13 @@
 
-MLTON       := mlton
-MLTON_FLAGS := -default-ann "nonexhaustiveMatch ignore"
+MLTON               := mlton
+MLTON_FLAGS         := -default-ann "nonexhaustiveMatch ignore"
 
-PREFIX      := /usr/local/mlton
+PREFIX              ?= /usr/local/mlton
+LIBDIR              ?= lib/SMLUnit
+DOCDIR              ?= doc/smlunit-lib
+
+SMLDOC              ?= smldoc
+SMLDOC_ARGFILE      := src/smldoc.cfg
 
 SMLUNITLIB_MLB      := smlunit-lib.mlb
 SMLUNITLIB_TEST_MLB := basis/test/sources.mlb
@@ -54,25 +59,48 @@ include $(EXAMPLE_MLB:.mlb=.mlb.d)
 endif
 
 
-.PHONY: install
-install: typecheck_smlunitlib $(SMLUNITLIB_MLB)
-	@[ -e $(PREFIX)/lib/SMLUnit ] || mkdir $(PREFIX)/lib/SMLUnit
+.PHONY: install-nodoc
+install-nodoc: typecheck_smlunitlib $(SMLUNITLIB_MLB)
+	@install -d $(PREFIX)/$(LIBDIR)
 	@$(MLTON) $(MLTON_FLAGS) -stop f $(SMLUNITLIB_MLB) | sed -e "1i./smlunitlib.mlb" | \
 	while read file; do \
 		if expr $$(readlink -f $$file) : ^$$(pwd) >/dev/null; then \
-			cp --parents $$(realpath --relative-to=$$(pwd) $$file) $(PREFIX)/lib/SMLUnit; \
+			cp --parents $$(realpath --relative-to=$$(pwd) $$file) $(PREFIX)/$(LIBDIR); \
 			echo -n . ; \
 		fi; \
 	done
 	@echo "Installation has been completed."
 	@echo "Please add the entry to your mlb path map file:"
 	@echo ""
-	@echo "  SMLUNIT_LIB $(PREFIX)/lib/SMLUnit"
+	@echo "  SMLUNIT_LIB $(PREFIX)/$(LIBDIR)"
 	@echo ""
+
+
+.PHONY: install
+install: install-doc install-nodoc
+
+
+.PHONY: doc
+doc:
+	@echo "  [SMLDoc]"
+	@$(RM) -r $(DOCDIR)
+	@install -d $(DOCDIR)
+	@$(SMLDOC) -c UTF-8 -a $(SMLDOC_ARGFILE) -d "$(DOCDIR)"
+
+
+.PHONY: install-doc
+install-doc: doc
+	@install -d $(PREFIX)/$(DOCDIR)
+	@cp -prT $(DOCDIR) $(PREFIX)/$(DOCDIR)
+	@echo "================================================================"
+	@echo "Generated API Documents of SMLUnit"
+	@echo "\t$(PREFIX)/$(DOCDIR)"
+	@echo "================================================================"
 
 
 .PHONY: clean
 clean:
+	-$(RM) -r $(DOCDIR)
 	-$(RM) $(SMLUNIT_MLBS:.mlb=)
 	-$(RM) $(SMLUNIT_MLBS:.mlb=.mlb.d)
 	-$(RM) $(EXAMPLES)

--- a/Makefile.mlton
+++ b/Makefile.mlton
@@ -1,6 +1,6 @@
 
 MLTON               := mlton
-MLTON_FLAGS         := -default-ann "nonexhaustiveMatch ignore"
+MLTON_FLAGS         := 
 
 PREFIX              := /usr/local/mlton
 LIBDIR              := lib/SMLUnit

--- a/Makefile.mlton
+++ b/Makefile.mlton
@@ -9,34 +9,43 @@ DOCDIR              ?= doc/smlunit-lib
 SMLDOC              ?= smldoc
 SMLDOC_ARGFILE      := src/smldoc.cfg
 
-SMLUNITLIB_MLB      := smlunit-lib.mlb
-SMLUNITLIB_TEST_MLB := basis/test/sources.mlb
-SMLUNIT_MLBS        := $(SMLUNITLIB_MLB)      \
-                       $(SMLUNITLIB_TEST_MLB)
+TYPECHECK_DUMMY     := bin/.smlunit-lib
 
-DEPENDS             := $(SMLUNIT_MLBS:.mlb=.mlb.d) \
-                       $(EXAMPLE_MLB:.mlb=.mlb.d)
+SMLUNITLIB_TEST_MLB := basis/test/sources.mlb
+SMLUNIT_MLBS        := smlunit-lib.mlb \
+                       $(SMLUNITLIB_TEST_MLB)
 
 EXAMPLES            := example/sources
 
 EXAMPLE_MLB         := $(EXAMPLES:=.mlb)
 
+DEPENDS             := $(SMLUNIT_MLBS:.mlb=.mlb.d) \
+                       $(EXAMPLE_MLB:.mlb=.mlb.d)
+
 SMLUNIT_LIB_DIR     := $(shell readlink -f .)
 
 
-all: typecheck_smlunitlib test example
+all: smlunit-lib
 
 
-.PHONY: typecheck_smlunitlib
-typecheck_smlunitlib: $(SMLUNITLIB_MLB)
-	@echo "  [MLTON] typecheck $<"
-	@$(MLTON) $(MLTON_FLAGS) -stop tc $<
+.PHONY: smlunit-lib-nodoc
+smlunit-lib-nodoc: $(TYPECHECK_DUMMY)
 
 
-$(EXAMPLE_MLB:.mlb=): MLTON_FLAGS += -mlb-path-var "SMLUNIT_LIB $(SMLUNIT_LIB_DIR)"
-$(SMLUNITLIB_TEST_MLB:.mlb=) $(EXAMPLE_MLB:.mlb=): %: %.mlb
+.PHONY: smlunit-lib
+smlunit-lib: smlunit-lib-nodoc doc
+
+
+$(TYPECHECK_DUMMY): smlunit-lib.mlb
 	@echo "  [MLTON] $@"
 	@$(MLTON) $(MLTON_FLAGS) -output $@ $<
+
+
+smlunit-lib.mlb.d: smlunit-lib.mlb
+	@echo "  [GEN] $@"
+	@$(SHELL) -ec '$(MLTON) $(MLTON_FLAGS) -stop f $< \
+		| sed -e "1i$(TYPECHECK_DUMMY) $@:\\\\" -e "s|.*|  & \\\\|" -e "\$$s| \\\\||" > $@; \
+		[ -s $@ ] || rm -rf $@'
 
 
 $(EXAMPLE_MLB:.mlb=.mlb.d): MLTON_FLAGS += -mlb-path-var "SMLUNIT_LIB $(SMLUNIT_LIB_DIR)"
@@ -47,24 +56,15 @@ $(EXAMPLE_MLB:.mlb=.mlb.d): MLTON_FLAGS += -mlb-path-var "SMLUNIT_LIB $(SMLUNIT_
 		[ -s $@ ] || rm -rf $@'
 
 
-.PHONY: test
-test: typecheck_smlunitlib $(SMLUNITLIB_TEST_MLB:.mlb=)
-	$(SMLUNITLIB_TEST_MLB:.mlb=)
-
-
-.PHONY: example
-example: typecheck_smlunitlib $(EXAMPLES)
-
-
 ifeq ($(findstring clean,$(MAKECMDGOALS)),)
   include $(DEPENDS)
 endif
 
 
 .PHONY: install-nodoc
-install-nodoc: typecheck_smlunitlib $(SMLUNITLIB_MLB)
+install-nodoc: smlunit-lib-nodoc
 	@install -d $(PREFIX)/$(LIBDIR)
-	@$(MLTON) $(MLTON_FLAGS) -stop f $(SMLUNITLIB_MLB) | sed -e "1i./smlunitlib.mlb" | \
+	@$(MLTON) $(MLTON_FLAGS) -stop f smlunit-lib.mlb | sed -e "1i./smlunitlib.mlb" | \
 	while read file; do \
 		if expr $$(readlink -f $$file) : ^$$(pwd) >/dev/null; then \
 			cp --parents $$(realpath --relative-to=$$(pwd) $$file) $(PREFIX)/$(LIBDIR); \
@@ -72,7 +72,7 @@ install-nodoc: typecheck_smlunitlib $(SMLUNITLIB_MLB)
 		fi; \
 	done
 	@echo "Installation has been completed."
-	@echo "Please add the entry to your mlb path map file:"
+	@echo "Add the entry to your mlb path map file:"
 	@echo ""
 	@echo "  SMLUNIT_LIB $(PREFIX)/$(LIBDIR)"
 	@echo ""
@@ -100,8 +100,28 @@ install-doc: doc
 	@echo "================================================================"
 
 
+$(EXAMPLE_MLB:.mlb=): MLTON_FLAGS += -mlb-path-var "SMLUNIT_LIB $(SMLUNIT_LIB_DIR)"
+$(SMLUNITLIB_TEST_MLB:.mlb=) $(EXAMPLE_MLB:.mlb=): %: %.mlb
+	@echo "  [MLTON] $@"
+	@$(MLTON) $(MLTON_FLAGS) -output $@ $<
+
+
+.PHONY: test
+test: $(SMLUNITLIB_TEST_MLB:.mlb=)
+	$(SMLUNITLIB_TEST_MLB:.mlb=)
+
+
+.PHONY: example
+example: $(EXAMPLES)
+	@for ex in $(EXAMPLES);do \
+		echo "$${ex}" ; \
+		$${ex}; \
+	done
+
+
 .PHONY: clean
 clean:
+	-$(RM) $(TYPECHECK_DUMMY)
 	-$(RM) -r $(DOCDIR)
 	-$(RM) $(DEPENDS)
 	-$(RM) $(SMLUNIT_MLBS:.mlb=)

--- a/basis/test/module.mlb
+++ b/basis/test/module.mlb
@@ -2,102 +2,107 @@
  * @author YAMATODANI Kiyoshi
  * @copyright 2010, Tohoku University.
  *)
-        $(SML_LIB)/basis/basis.mlb
+ann
+  "nonexhaustiveMatch ignore"
+  "nonexhaustiveBind ignore"
+in
+  $(SML_LIB)/basis/basis.mlb
 
-        ../../smlunit-lib.mlb
+  ../../smlunit-lib.mlb
 
-        (****************************************)
-        (* Tests for required modules. *)
+  (****************************************)
+  (* Tests for required modules. *)
 
-        (* sequence modules *)
-        SEQUENCE.sig
-        Sequence101.sml
-        Array101.sml
-        CharArray101.sml
-        CharVector101.sml
-        Vector101.sml
-        Word8Array101.sml
-        Word8Vector101.sml
+  (* sequence modules *)
+  SEQUENCE.sig
+  Sequence101.sml
+  Array101.sml
+  CharArray101.sml
+  CharVector101.sml
+  Vector101.sml
+  Word8Array101.sml
+  Word8Vector101.sml
 
-        MUTABLE_SEQUENCE.sig
-        MutableSequence001.sml
-        Array001.sml
-        CharArray001.sml
-        Word8Array001.sml
+  MUTABLE_SEQUENCE.sig
+  MutableSequence001.sml
+  Array001.sml
+  CharArray001.sml
+  Word8Array001.sml
 
-        IMMUTABLE_SEQUENCE.sig
-        ImmutableSequence001.sml
-        CharVector001.sml
-        Vector001.sml
-        Word8Vector001.sml
+  IMMUTABLE_SEQUENCE.sig
+  ImmutableSequence001.sml
+  CharVector001.sml
+  Vector001.sml
+  Word8Vector001.sml
 
-        (* sequence slice modules *)
-        SEQUENCE_SLICE.sig
-        SequenceSlice101.sml
-        ArraySlice101.sml
-        CharArraySlice101.sml
-        CharVectorSlice101.sml
-        VectorSlice101.sml
-        Word8ArraySlice101.sml
-        Word8VectorSlice101.sml
+  (* sequence slice modules *)
+  SEQUENCE_SLICE.sig
+  SequenceSlice101.sml
+  ArraySlice101.sml
+  CharArraySlice101.sml
+  CharVectorSlice101.sml
+  VectorSlice101.sml
+  Word8ArraySlice101.sml
+  Word8VectorSlice101.sml
 
-        MUTABLE_SEQUENCE_SLICE.sig
-        MutableSequenceSlice001.sml
-        ArraySlice001.sml
-        CharArraySlice001.sml
-        Word8ArraySlice001.sml
+  MUTABLE_SEQUENCE_SLICE.sig
+  MutableSequenceSlice001.sml
+  ArraySlice001.sml
+  CharArraySlice001.sml
+  Word8ArraySlice001.sml
 
-        IMMUTABLE_SEQUENCE_SLICE.sig
-        ImmutableSequenceSlice001.sml
-        VectorSlice001.sml
-        CharVectorSlice001.sml
-        Word8VectorSlice001.sml
+  IMMUTABLE_SEQUENCE_SLICE.sig
+  ImmutableSequenceSlice001.sml
+  VectorSlice001.sml
+  CharVectorSlice001.sml
+  Word8VectorSlice001.sml
 
-        (* INTEGER modules *)
-        SignedInteger001.sml
-        Int001.sml
-        LargeInt001.sml
-        Position001.sml
+  (* INTEGER modules *)
+  SignedInteger001.sml
+  Int001.sml
+  LargeInt001.sml
+  Position001.sml
 
-        (* WORD modules *)
-        UnsignedInteger001.sml
-        Word001.sml
-        Word8001.sml
-        LargeWord001.sml
+  (* WORD modules *)
+  UnsignedInteger001.sml
+  Word001.sml
+  Word8001.sml
+  LargeWord001.sml
 
-        (* other Basis modules *)
-        Bool001.sml
-        Byte001.sml
-        Char001.sml
-        Date001.sml
-        General001.sml
-        IEEEReal001.sml
-        List001.sml
-        ListPair001.sml
-        Math001.sml
-        Option001.sml
-        Real001.sml
-        String001.sml
-        StringCvt001.sml
-        Substring001.sml
-        Time001.sml
+  (* other Basis modules *)
+  Bool001.sml
+  Byte001.sml
+  Char001.sml
+  Date001.sml
+  General001.sml
+  IEEEReal001.sml
+  List001.sml
+  ListPair001.sml
+  Math001.sml
+  Option001.sml
+  Real001.sml
+  String001.sml
+  StringCvt001.sml
+  Substring001.sml
+  Time001.sml
 
-        TestRequiredModules.sml
+  TestRequiredModules.sml
 
-        (****************************************)
-        (* Tests for optional modules. *)
+  (****************************************)
+  (* Tests for optional modules. *)
 
-        IntInf001.sml
-        IntInf101.sml
-        RealArray001.sml
-        RealArray101.sml
-        RealVector001.sml
-        RealVector101.sml
+  IntInf001.sml
+  IntInf101.sml
+  RealArray001.sml
+  RealArray101.sml
+  RealVector001.sml
+  RealVector101.sml
 
-        MUTABLE_2D_SEQUENCE.sig
-        Mutable2DSequence001.sml
-        Array2001.sml
-        CharArray2001.sml
-        Word8Array2001.sml
+  MUTABLE_2D_SEQUENCE.sig
+  Mutable2DSequence001.sml
+  Array2001.sml
+  CharArray2001.sml
+  Word8Array2001.sml
 
-        TestOptionalModules_MLton.sml
+  TestOptionalModules_MLton.sml
+end

--- a/example/Main.smi
+++ b/example/Main.smi
@@ -1,3 +1,11 @@
 _require "basis.smi"
 _require "smlunit-lib.smi"
 _require "TestDictionary.smi"
+
+structure Main =
+struct
+  val main : string * string list -> OS.Process.status
+
+  val main' : unit -> OS.Process.status
+end
+

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,10 +1,12 @@
 SMLSHARP_ENV = SMLSHARP_HEAPSIZE=128M:1G
 SMLSHARP = smlsharp
 SMLFLAGS = -O2
-ALLOBJECTS = Main.o TestDictionary.o Dictionary.o
+ALLOBJECTS = call-main.o Main.o TestDictionary.o Dictionary.o
 
 testExec: $(ALLOBJECTS)
-	$(SMLSHARP_ENV) $(SMLSHARP) $(SMLFLAGS) -o testExec Main.smi
+	$(SMLSHARP_ENV) $(SMLSHARP) $(SMLFLAGS) -o testExec call-main.smi
+
+call-main.o: call-main.smi call-main.sml Main.smi
 
 Dictionary.o: Dictionary.sml Dictionary.smi DICTIONARY.sig Dictionary.smi
 

--- a/example/call-main.smi
+++ b/example/call-main.smi
@@ -1,0 +1,1 @@
+_require "Main.smi"

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ What is this
 
  * A general unit testing frame work for SML system(# is not required)
  * This is imported from SML#v3.6.0 unofficial repository (https://github.com/smlsharp/smlsharp/tree/v3.6.0)
- * This framework support SML#, SML/NJ and MLton explicitly
+ * This framework support SML#, [SML/NJ] and [MLton] explicitly
  ** build scripts Makefile(for SML#), CM file(for SML/NJ) and MLB file(for MLton) are included.
 
 Setup
@@ -63,7 +63,7 @@ $ smlsharp -I/path/to/smlunit -L/path/to/smlunit -o test_foo test_foo.smi
 
 #### Install
 
-To install SMLUnit for SML/NJ, run `make install` with `Makefile.smlnj`:
+To install SMLUnit for [SML/NJ], run `make install` with `Makefile.smlnj`:
 
 ```sh
 $ make -f Makefile.smlnj install
@@ -75,7 +75,7 @@ To specify the directory to install to, run `make` with the variable `PREFIX`:
 $ make -f Makefile.smlnj install PREFIX=~/.sml/smlnj
 ```
 
-The `install` target uses `SMLDoc` to generate the documentations for SMLUnit.
+The `install` target uses [SMLDoc] to generate the documentations for SMLUnit.
 If you do not need to generate documentation, run the `install-nodoc` target.
 
 ```sh
@@ -119,7 +119,7 @@ $ make -f Makefile.smlnj example
 
 #### Install
 
-To install SMLUnit for MLton, run `make install` with `Makefile.mlton`:
+To install SMLUnit for [MLton], run `make install` with `Makefile.mlton`:
 
 ```sh
 $ make -f Makefile.mlton install
@@ -130,6 +130,13 @@ This install location can be set with `PREFIX` variable like:
 
 ```sh
 $ make -f Makefile.mlton PREFIX=~/.sml/mlton install
+```
+
+The `install` target uses [SMLDoc] to generate the documentations for SMLUnit.
+If you do not need to generate documentation, run the `install-nodoc` target.
+
+```sh
+$ make -f Makefile.mlton install-nodoc
 ```
 
 After running the `install` target, add an entry for `SMLUNIT_LIB` to your mlb path mapping file:
@@ -242,4 +249,10 @@ tests = 5, failures = 0, errors = 0
 Failures:
 Errors:
 ```
+
+[SML/NJ]: https://www.smlnj.org/ "Standard ML of New Jersey"
+
+[MLton]: https://www.mlton.org/ "MLton"
+
+[SMLDoc]: https://www.pllab.riec.tohoku.ac.jp/smlsharp//?SMLDoc "SMLDoc"
 

--- a/readme.md
+++ b/readme.md
@@ -126,7 +126,7 @@ $ make -f Makefile.mlton install
 ```
 
 Above command install SMLUnit to `/usr/local/mlton`.
-This install location can be set with `PREFIX` variable.
+This install location can be set with `PREFIX` variable like:
 
 ```sh
 $ make -f Makefile.mlton PREFIX=~/.sml/mlton install
@@ -148,9 +148,10 @@ $(SMLUNIT_LIB)/smlunit-lib.mlb
 .
 ```
 
+
 #### Test
 
-To run SMLUnit unit test, run the `test` target:
+To run SMLUnit unit tests, run the `test` target:
 
 ```sh
 $ make -f Makefile.mlton test


### PR DESCRIPTION
Improve Makefile for MLton.
The file `Makefile.mlton` provides following targets:

- `smlunit-lib`, `smlunit-lib-nodoc`
  Build the library.
- `install` and `install-nodoc`
  Install the library.
  After `make install`, you needed to add an entry to your mlb-path-map file like `SMLUNIT_LIB /path/to/smlunit`.
- `doc`
  Generate documentation to ./doc.
- `test` and `example`
  Build and execute sample programs.
- `clean`
  Delete intermediate files.

These all targets are same to targets provided with Makefile.smlnj.
