### PR TITLE
Improve makefile for polyml

### DIFF
--- a/Makefile.polyml
+++ b/Makefile.polyml
@@ -10,10 +10,10 @@ DOCDIR         := doc/smlunit-lib
 SMLDOC         := smldoc
 SMLDOC_ARGFILE := src/smldoc.cfg
 
-SRC            := $(wildcard src/main/*.sml)
+SRC            := $(wildcard src/main/*.sml src/main/*.sig)
 TEST_SRC       := $(wildcard src/test/*.sml)
-BASIS_TEST_SRC := $(wildcard basis/test/*.sml)
-EXAMPLE_SRC    := $(wildcard example/*.sml)
+BASIS_TEST_SRC := $(wildcard basis/test/*.sml basis/test/*.sig)
+EXAMPLE_SRC    := $(wildcard example/*.sml example/*.sig)
 
 SMLUNIT_LIB    := smlunit-lib.poly
 TEST           := bin/smlunit-test-poly bin/smlunit-basis-test-poly

--- a/Makefile.polyml
+++ b/Makefile.polyml
@@ -1,18 +1,23 @@
 
-POLYML         ?= poly
-POLYMLC        ?= polyc
-POLYMLFLAGS    ?= -q --error-exit --eval 'PolyML.suffixes := ".sig"::(!PolyML.suffixes)'
+POLYML         := poly
+POLYMLC        := polyc
+POLYMLFLAGS    := -q --error-exit --eval 'PolyML.suffixes := ".sig"::(!PolyML.suffixes)'
 
-PREFIX         ?= /usr/local
+PREFIX         := /usr/local/polyml
+LIBDIR         := lib/smlunit-lib
+DOCDIR         := doc/smlunit-lib
 
-SRC            := $(wildcard src/main/*)
-TEST_SRC       := $(wildcard src/test/*)
-BASIS_TEST_SRC := $(wildcard ./basis/test/*)
-EXAMPLE_SRC    := $(wildcard ./example/*)
+SMLDOC         := smldoc
+SMLDOC_ARGFILE := src/smldoc.cfg
 
-TARGET         := libsmlunit.poly
-TEST           := smlunit-test-poly smlunit-basis-test-poly
-EXAMPLE        := smlunit-example-poly
+SRC            := $(wildcard src/main/*.sml)
+TEST_SRC       := $(wildcard src/test/*.sml)
+BASIS_TEST_SRC := $(wildcard basis/test/*.sml)
+EXAMPLE_SRC    := $(wildcard example/*.sml)
+
+SMLUNIT_LIB    := smlunit-lib.poly
+TEST           := bin/smlunit-test-poly bin/smlunit-basis-test-poly
+EXAMPLE        := bin/smlunit-example-poly
 
 define export-module
 @echo "  [POLYML] $@"
@@ -23,27 +28,35 @@ define export-module
 endef
 
 
-all: $(TARGET)
+all: smlunit-lib
 
 
-$(TARGET): $(SRC)
+.PHONY: smlunit-lib-nodoc
+smlunit-lib-nodoc: $(SMLUNIT_LIB)
+
+
+.PHONY: smlunit-lib
+smlunit-lib: smlunit-lib-nodoc doc
+
+
+$(SMLUNIT_LIB): export.sml $(SRC)
 	@echo "  [POLYML] $@"
 	@echo "" | $(POLYML) $(POLYMLFLAGS) \
 		--eval 'PolyML.make "src/main"' \
 		--use export.sml \
-		--eval 'PolyML.SaveState.saveModule ("$(TARGET)", SMLUnit)'
+		--eval 'PolyML.SaveState.saveModule ("$(SMLUNIT_LIB)", SMLUnit)'
 
 
-smlunit-test-poly.o: $(TARGET) $(TEST_SRC)
-	$(call export-module,TestMain.test,src/test,./$(TARGET))
+bin/smlunit-test-poly.o: $(SMLUNIT_LIB) $(TEST_SRC)
+	$(call export-module,TestMain.test,src/test,./$<)
 
 
-smlunit-basis-test-poly.o: $(TARGET) $(BASIS_TEST_SRC)
-	$(call export-module,TestMain.test,basis/test,./$(TARGET))
+bin/smlunit-basis-test-poly.o: $(SMLUNIT_LIB) $(BASIS_TEST_SRC)
+	$(call export-module,TestMain.test,basis/test,./$<)
 
 
-$(EXAMPLE).o: $(TARGET) $(EXAMPLE_SRC)
-	$(call export-module,Main.main'\'',example,./$(TARGET))
+$(EXAMPLE).o: $(SMLUNIT_LIB) $(EXAMPLE_SRC)
+	$(call export-module,Main.main'\'',example,./$<)
 
 
 $(TEST) $(EXAMPLE): %: %.o
@@ -51,26 +64,57 @@ $(TEST) $(EXAMPLE): %: %.o
 	@$(POLYMLC) -o $@ $^
 
 
-.PHONY: example
-example: $(EXAMPLE)
-	./$(EXAMPLE)
+.PHONY: install-nodoc
+install-nodoc: smlunit-lib-nodoc
+	@install -D -m 644 -t $(PREFIX)/$(LIBDIR) $(SMLUNIT_LIB)
+	@echo "================================================================"
+	@echo "smlunit-lib has been installed to:"
+	@echo "\t$(PREFIX)/$(LIBDIR)/$(SMLUNIT_LIB)"
+	@echo "================================================================"
 
 
 .PHONY: install
-install: $(TARGET)
-	@[ -e $(PREFIX)/polyml/lib ] || mkdir $(PREFIX)/polyml/lib
-	install -D -m 644 -t $(PREFIX)/polyml/lib $(TARGET)
+install: install-doc install-nodoc
+
+
+.PHONY: doc
+doc:
+	@echo "  [SMLDoc]"
+	@$(RM) -r $(DOCDIR)
+	@install -d $(DOCDIR)
+	@$(SMLDOC) -c UTF-8 -a $(SMLDOC_ARGFILE) -d "$(DOCDIR)"
+
+
+.PHONY: install-doc
+install-doc: doc
+	@install -d $(PREFIX)/$(DOCDIR)
+	@cp -prT $(DOCDIR) $(PREFIX)/$(DOCDIR)
+	@echo "================================================================"
+	@echo "Generated API Documents of SMLUnit"
+	@echo "\t$(PREFIX)/$(DOCDIR)"
+	@echo "================================================================"
 
 
 .PHONY: test
 test: $(TEST)
-	./smlunit-test-poly
-	./smlunit-basis-test-poly
+	@for exe in $^;do \
+		echo "$${exe}" ; \
+		$${exe} ; \
+	done
+
+
+.PHONY: example
+example: $(EXAMPLE)
+	@for exe in $^;do \
+		echo "$${exe}" ; \
+		$${exe} ; \
+	done
 
 
 .PHONY: clean
 clean:
-	-$(RM) $(TARGET)
+	-$(RM) $(SMLUNIT_LIB)
+	-$(RM) -r $(DOCDIR)
 	-$(RM) $(TEST)
 	-$(RM) $(TEST:=.o)
 	-$(RM) $(EXAMPLE)

--- a/readme.md
+++ b/readme.md
@@ -199,7 +199,7 @@ If you do not need to generate documentation, run the `install-nodoc` target.
 $ make -f Makefile.polyml install-nodoc
 ```
 
-Then you will get `smlunit-lib.poly` in `PREFIX/lib/smlunitlib` which is the collection of SMLUnit entities.
+Then you will get `smlunit-lib.poly` in `PREFIX/lib/smlunit-lib` which is the collection of SMLUnit entities.
 It is possible to load directly into the REPL:
 
 ```sh

--- a/readme.md
+++ b/readme.md
@@ -16,8 +16,7 @@ What is this
 
  * A general unit testing frame work for SML system(# is not required)
  * This is imported from SML#v3.6.0 unofficial repository (https://github.com/smlsharp/smlsharp/tree/v3.6.0)
- * This framework support SML#, [SML/NJ] and [MLton] explicitly
- ** build scripts Makefile(for SML#), CM file(for SML/NJ) and MLB file(for MLton) are included.
+ * This framework support SML#, [SML/NJ], [MLton] and [Poly/ML] explicitly
 
 Setup
 ------------------------------
@@ -181,7 +180,7 @@ $ make -f Makefile.smlnj example
 
 #### Install
 
-To install SMLUnit for [PolyML], run the `install` target.
+To install SMLUnit for [Poly/ML], run the `install` target.
 
 ```sh
 $ make -f Makefile.polyml install
@@ -247,7 +246,7 @@ Errors:
 
 [MLton]: https://www.mlton.org/ "MLton"
 
-[PolyML]: https://www.polyml.org/ "PolyML"
+[Poly/ML]: https://www.polyml.org/ "PolyML"
 
 [SMLDoc]: https://www.pllab.riec.tohoku.ac.jp/smlsharp//?SMLDoc "SMLDoc"
 

--- a/readme.md
+++ b/readme.md
@@ -1,25 +1,21 @@
-SMLUnit:  Unit Testing Framework for SML(#)
-============================================================
+# SMLUnit:  Unit Testing Framework for SML(#)
 
 This is **unofficial** repository for SMLUnit.
 
 If you get official information, see http://www.pllab.riec.tohoku.ac.jp/smlsharp/?SMLUnit .
 
-What is **not** this
-------------------------------
+## What is **not** this
 
  * This is not official repository.
  * There is no relationship with SML# deveploment team or Tohoku University.
 
-What is this
-------------------------------
+## What is this
 
  * A general unit testing frame work for SML system(# is not required)
  * This is imported from SML#v3.6.0 unofficial repository (https://github.com/smlsharp/smlsharp/tree/v3.6.0)
  * This framework support SML#, [SML/NJ], [MLton] and [Poly/ML] explicitly
 
-Setup
-------------------------------
+## Setup
 
 ### SML&#x23;
 

--- a/readme.md
+++ b/readme.md
@@ -108,7 +108,7 @@ Depending on the test case, it will fails.
 
 #### Examples
 
-To run the example program, run `example` target:
+To run the example program, run the `example` target:
 
 ```sh
 $ make -f Makefile.smlnj example
@@ -178,24 +178,34 @@ $ make -f Makefile.smlnj example
 
 ### PolyML
 
-To build, just `make`:
+
+#### Install
+
+To install SMLUnit for [PolyML], run the `install` target.
 
 ```sh
-$ make -f Makefile.polyml
-  [POLYML] libsmlunit.poly
-Making main
-Making SMLUnit
-..
-Created structure SMLUnit
+$ make -f Makefile.polyml install
 ```
 
-Then you will get `./libsmlunit.poly` which is the collection of SMLUnit entities that can be loaded.
+To specify the directory to install to, run `make` with the variable `PREFIX`:
 
+```sh
+$ make -f Makefile.polyml PREFIX=~/.sml/polyml/5.8.1 install
+```
+
+The `install` target uses `SMLDoc` to generate the documentations for SMLUnit.
+If you do not need to generate documentation, run the `install-nodoc` target.
+
+```sh
+$ make -f Makefile.polyml install-nodoc
+```
+
+Then you will get `smlunit-lib.poly` in `PREFIX/lib/smlunitlib` which is the collection of SMLUnit entities.
 It is possible to load directly into the REPL:
 
 ```sh
 $ poly
-> PolyML.loadModule "/path/to/libsmlunit.poly";
+> PolyML.loadModule "/path/to/smlunit-lib.poly";
 signature ASSERT =
   sig
 ..
@@ -204,46 +214,29 @@ signature TESTRUNNER =
 val it = (): unit
 ```
 
+
 #### Test
 
-Execute unit tests for SMLUnit, run `test` target:
+To run SMLUnit unit tests, run the `test` target:
 
 ```sh
 $ make -f Makefile.polyml test
 ```
 
-In some test cases, it will fails.
+Depending on the test case, it will fails.
 
-
-#### Install
-
-To install [SMLUnit] for [PolyML], perform `install` target.
-
-```sh
-$ make -f Makefile.polyml install
-install -D -m 644 -t /usr/local/polyml/lib libsmlunit.poly
-```
-
-You can change installation directory with `PREFIX` variable:
-
-```sh
-$ make -f Makefile.polyml PREFIX=~/.sml install
-install -D -m 644 -t /home/<user>/.sml/polyml/lib libsmlunit.poly
-```
 
 #### Examples
 
-To run examples with Poly/ML, run the `example` target:
+To run the example program, run the `example` target:
 
 ```sh
 
 $ make -f Makefile.polyml example
-  [POLYML] libsmlunit.poly
+  [POLYML] bin/smlunit-example-poly.o
 ..
-  [POLYML] smlunit-example-poly.o
-..
-  [POLYC] smlunit-example-poly
-./smlunit-example-poly
+  [POLYC] bin/smlunit-example-poly
+bin/smlunit-example-poly
 .....
 tests = 5, failures = 0, errors = 0
 Failures:

--- a/readme.md
+++ b/readme.md
@@ -193,7 +193,7 @@ To specify the directory to install to, run `make` with the variable `PREFIX`:
 $ make -f Makefile.polyml PREFIX=~/.sml/polyml/5.8.1 install
 ```
 
-The `install` target uses `SMLDoc` to generate the documentations for SMLUnit.
+The `install` target uses [SMLDoc] to generate the documentations for SMLUnit.
 If you do not need to generate documentation, run the `install-nodoc` target.
 
 ```sh
@@ -246,6 +246,8 @@ Errors:
 [SML/NJ]: https://www.smlnj.org/ "Standard ML of New Jersey"
 
 [MLton]: https://www.mlton.org/ "MLton"
+
+[PolyML]: https://www.polyml.org/ "PolyML"
 
 [SMLDoc]: https://www.pllab.riec.tohoku.ac.jp/smlsharp//?SMLDoc "SMLDoc"
 


### PR DESCRIPTION
Improve Makefile for Poly/ML.
The file `Makefile.polyml` provides following targets:

- `smlunit-lib`, `smlunit-lib-nodoc`
  Build the library.
- `install` and `install-nodoc`
  Install the library.
- `doc`
  Generate documentation to ./doc.
- `test` and `example`
  Build and execute sample programs.
- `clean`
  Delete intermediate files.

These all targets are same to targets provided with `Makefile.smlnj` and `Makefile.mlton`.
