### PR TITLE
Tweak makefile style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+doc/api
 # depend
 *.d
 # object

--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,14 @@
 doc/api
 # depend
-*.d
+*.cm.d
+*.mlb.d
 # object
 *.o
 # sml/nj
 bin/
 .cm/
-# mlton
-bin/.smlunit-lib
-# library
-libsmlunit.poly
+# polyml
+smlunit-lib.poly
 # test executable
 smlunit-test-poly
 smlunit-basis-test-poly

--- a/Makefile.mlton
+++ b/Makefile.mlton
@@ -4,7 +4,7 @@ MLTON_FLAGS         :=
 
 PREFIX              := /usr/local/mlton
 LIBDIR              := lib/SMLUnit
-DOCDIR              := doc/smlunit-lib
+DOCDIR              := $(PREFIX)/doc
 
 SMLDOC              := smldoc
 SMLDOC_ARGFILE      := src/smldoc.cfg
@@ -86,18 +86,18 @@ install: install-doc install-nodoc
 .PHONY: doc
 doc:
 	@echo "  [SMLDoc]"
-	@$(RM) -r $(DOCDIR)
-	@install -d $(DOCDIR)
-	@$(SMLDOC) -c UTF-8 -a $(SMLDOC_ARGFILE) -d "$(DOCDIR)"
+	@$(RM) -r doc/api
+	@install -d doc/api
+	@$(SMLDOC) -c UTF-8 -a $(SMLDOC_ARGFILE) -d doc/api
 
 
 .PHONY: install-doc
 install-doc: doc
-	@install -d $(PREFIX)/$(DOCDIR)
-	@cp -prT $(DOCDIR) $(PREFIX)/$(DOCDIR)
+	@install -d $(DOCDIR)
+	@cp -prT doc $(DOCDIR)/smlunit-lib
 	@echo "================================================================"
 	@echo "Generated API Documents of SMLUnit"
-	@echo "\t$(PREFIX)/$(DOCDIR)"
+	@echo "\t$(DOCDIR)/smlunit-lib"
 	@echo "================================================================"
 
 
@@ -126,7 +126,7 @@ example: $(EXAMPLE_MLB:.mlb=)
 .PHONY: clean
 clean:
 	-$(RM) $(TYPECHECK_DUMMY)
-	-$(RM) -r $(DOCDIR)
+	-$(RM) -r doc/api
 	-$(RM) $(DEPENDS)
 	-$(RM) $(filter-out smlunit-lib,$(SMLUNIT_MLBS:.mlb=))
 

--- a/Makefile.mlton
+++ b/Makefile.mlton
@@ -3,24 +3,34 @@ MLTON               := mlton
 MLTON_FLAGS         := 
 
 PREFIX              := /usr/local/mlton
-LIBDIR              := lib/SMLUnit
+BINDIR              := $(PREFIX)/bin
+LIBDIR              := $(PREFIX)/lib
 DOCDIR              := $(PREFIX)/doc
 
 SMLDOC              := smldoc
 SMLDOC_ARGFILE      := src/smldoc.cfg
 
-TYPECHECK_DUMMY     := bin/.smlunit-lib
+SMLUNIT_LIB         := bin/.smlunit-lib.dummy
+SMLUNIT_LIB_COMPAT  := bin/.smlunitlib.dummy
+
+TEST_TARGET         := bin/smlunit-src-test \
+                       bin/smlunit-basis-test
+
+EXAMPLE_TARGET      := bin/smlunit-example
 
 TEST_MLB            := src/test/sources.mlb \
                        basis/test/sources.mlb
 
 EXAMPLE_MLB         := example/sources.mlb
 
-SMLUNIT_MLBS        := smlunit-lib.mlb \
-                       $(TEST_MLB) \
-                       $(EXAMPLE_MLB)
+SMLUNIT_MLB         := smlunit-lib.mlb \
+                       smlunitlib.mlb
 
-DEPENDS             := $(SMLUNIT_MLBS:.mlb=.mlb.d)
+DEPENDS             := $(SMLUNIT_MLB:.mlb=.mlb.d)
+
+TEST_DEPENDS        := $(TEST_MLB:.mlb=.mlb.d)
+
+EXAMPLE_DEPENDS     := $(EXAMPLE_MLB:.mlb=.mlb.d)
 
 SMLUNIT_LIB_DIR     := $(shell readlink -f .)
 
@@ -29,24 +39,17 @@ all: smlunit-lib
 
 
 .PHONY: smlunit-lib-nodoc
-smlunit-lib-nodoc: $(TYPECHECK_DUMMY)
+smlunit-lib-nodoc: $(SMLUNIT_LIB) $(SMLUNIT_LIB_COMPAT)
 
 
 .PHONY: smlunit-lib
 smlunit-lib: smlunit-lib-nodoc doc
 
 
-$(TYPECHECK_DUMMY): smlunit-lib.mlb
+$(SMLUNIT_LIB) $(SMLUNIT_LIB_COMPAT): bin/.%.dummy: %.mlb
 	@echo "  [MLTON] $@"
 	@$(MLTON) $(MLTON_FLAGS) -stop tc $<
-	@touch $@
-
-
-smlunit-lib.mlb.d: smlunit-lib.mlb
-	@echo "  [GEN] $@"
-	@$(SHELL) -ec '$(MLTON) $(MLTON_FLAGS) -stop f $< \
-		| sed -e "1i$(TYPECHECK_DUMMY) $@:\\\\" -e "s|.*|  & \\\\|" -e "\$$s| \\\\||" > $@; \
-		[ -s $@ ] || rm -rf $@'
+	@echo "typecheck dummy with: $(MLTON) $(MLTON_FLAGS) -stop tc $<" > $@
 
 
 $(EXAMPLE_MLB:.mlb=.mlb.d): MLTON_FLAGS += -mlb-path-var "SMLUNIT_LIB $(SMLUNIT_LIB_DIR)"
@@ -54,7 +57,7 @@ $(EXAMPLE_MLB:.mlb=.mlb.d): MLTON_FLAGS += -mlb-path-var "SMLUNIT_LIB $(SMLUNIT_
 	@echo "  [GEN] $@"
 	@$(SHELL) -ec '$(MLTON) $(MLTON_FLAGS) -stop f $< \
 		| sed -e "1i$(<:.mlb=) $@:\\\\" -e "s|.*|  & \\\\|" -e "\$$s| \\\\||" > $@; \
-		[ -s $@ ] || rm -rf $@'
+		[ -s $@ ]'
 
 
 ifeq ($(findstring clean,$(MAKECMDGOALS)),)
@@ -62,20 +65,30 @@ ifeq ($(findstring clean,$(MAKECMDGOALS)),)
 endif
 
 
+ifneq ($(findstring test,$(MAKECMDGOALS)),)
+  include $(TEST_DEPENDS)
+endif
+
+
+ifneq ($(findstring example,$(MAKECMDGOALS)),)
+  include $(EXAMPLE_DEPENDS)
+endif
+
+
 .PHONY: install-nodoc
-install-nodoc: smlunit-lib-nodoc
-	@install -d $(PREFIX)/$(LIBDIR)
+install-nodoc: $(SMLUNIT_LIB) $(SMLUNIT_LIB_COMPAT)
+	@install -d $(LIBDIR)/SMLUnit
 	@$(MLTON) $(MLTON_FLAGS) -stop f smlunit-lib.mlb | sed -e "1i./smlunitlib.mlb" | \
 	while read file; do \
 		if expr $$(readlink -f $$file) : ^$$(pwd) >/dev/null; then \
-			cp --parents $$(realpath --relative-to=$$(pwd) $$file) $(PREFIX)/$(LIBDIR); \
+			cp --parents $$(realpath --relative-to=$$(pwd) $$file) $(LIBDIR)/SMLUnit; \
 			echo -n . ; \
 		fi; \
 	done
 	@echo "Installation has been completed."
 	@echo "Add the entry to your mlb path map file:"
 	@echo ""
-	@echo "  SMLUNIT_LIB $(PREFIX)/$(LIBDIR)"
+	@echo "  SMLUNIT_LIB $(LIBDIR)/SMLUnit"
 	@echo ""
 
 
@@ -107,26 +120,39 @@ $(TEST_MLB:.mlb=) $(EXAMPLE_MLB:.mlb=): %: %.mlb
 	@$(MLTON) $(MLTON_FLAGS) -output $@ $<
 
 
+$(TEST_TARGET): bin/smlunit-%-test: %/test/sources
+	@echo "  [CP] $@"
+	@cp $< $@
+
+
 .PHONY: test
-test: $(TEST_MLB:.mlb=)
+test: $(TEST_TARGET)
 	@for exe in $^;do \
-		echo "$${exe}" ; \
-		$${exe} ; \
+	   echo "$${exe}" ; \
+	   $${exe} ; \
 	done
+
+
+$(EXAMPLE_TARGET): example/sources
+	@echo "  [CP] $@"
+	@cp $< $@
 
 
 .PHONY: example
-example: $(EXAMPLE_MLB:.mlb=)
-	@for exe in $^;do \
-		echo "$${exe}" ; \
-		$${exe} ; \
-	done
+example: $(EXAMPLE_TARGET)
+	./$(EXAMPLE_TARGET)
 
 
 .PHONY: clean
 clean:
-	-$(RM) $(TYPECHECK_DUMMY)
-	-$(RM) -r doc/api
+	-$(RM) $(SMLUNIT_LIB)
+	-$(RM) $(SMLUNIT_LIB_COMPAT)
 	-$(RM) $(DEPENDS)
-	-$(RM) $(filter-out smlunit-lib,$(SMLUNIT_MLBS:.mlb=))
+	-$(RM) $(TEST_TARGET)
+	-$(RM) $(TEST_MLB:.mlb=)
+	-$(RM) $(TEST_DEPENDS)
+	-$(RM) $(EXAMPLE_TARGET)
+	-$(RM) $(EXAMPLE_MLB:.mlb=)
+	-$(RM) $(EXAMPLE_DEPENDS)
+	-$(RM) -r doc/api
 

--- a/Makefile.polyml
+++ b/Makefile.polyml
@@ -5,7 +5,7 @@ POLYMLFLAGS    := -q --error-exit --eval 'PolyML.suffixes := ".sig"::(!PolyML.su
 
 PREFIX         := /usr/local/polyml
 LIBDIR         := lib/smlunit-lib
-DOCDIR         := doc/smlunit-lib
+DOCDIR         := $(PREFIX)/doc
 
 SMLDOC         := smldoc
 SMLDOC_ARGFILE := src/smldoc.cfg
@@ -80,18 +80,18 @@ install: install-doc install-nodoc
 .PHONY: doc
 doc:
 	@echo "  [SMLDoc]"
-	@$(RM) -r $(DOCDIR)
-	@install -d $(DOCDIR)
-	@$(SMLDOC) -c UTF-8 -a $(SMLDOC_ARGFILE) -d "$(DOCDIR)"
+	@$(RM) -r doc/api
+	@install -d doc/api
+	@$(SMLDOC) -c UTF-8 -a $(SMLDOC_ARGFILE) -d doc/api
 
 
 .PHONY: install-doc
 install-doc: doc
-	@install -d $(PREFIX)/$(DOCDIR)
-	@cp -prT $(DOCDIR) $(PREFIX)/$(DOCDIR)
+	@install -d $(DOCDIR)
+	@cp -prT doc $(DOCDIR)/smlunit-lib
 	@echo "================================================================"
 	@echo "Generated API Documents of SMLUnit"
-	@echo "\t$(PREFIX)/$(DOCDIR)"
+	@echo "\t$(DOCDIR)/smlunit-lib"
 	@echo "================================================================"
 
 
@@ -114,7 +114,7 @@ example: $(EXAMPLE)
 .PHONY: clean
 clean:
 	-$(RM) $(SMLUNIT_LIB)
-	-$(RM) -r $(DOCDIR)
+	-$(RM) -r doc/api
 	-$(RM) $(TEST)
 	-$(RM) $(TEST:=.o)
 	-$(RM) $(EXAMPLE)

--- a/Makefile.polyml
+++ b/Makefile.polyml
@@ -4,7 +4,7 @@ POLYMLC        := polyc
 POLYMLFLAGS    := -q --error-exit --eval 'PolyML.suffixes := ".sig"::(!PolyML.suffixes)'
 
 PREFIX         := /usr/local/polyml
-LIBDIR         := lib/smlunit-lib
+LIBDIR         := $(PREFIX)/lib
 DOCDIR         := $(PREFIX)/doc
 
 SMLDOC         := smldoc
@@ -44,7 +44,7 @@ $(SMLUNIT_LIB): export.sml $(SRC)
 	@echo "" | $(POLYML) $(POLYMLFLAGS) \
 		--eval 'PolyML.make "src/main"' \
 		--use export.sml \
-		--eval 'PolyML.SaveState.saveModule ("$(SMLUNIT_LIB)", SMLUnit)'
+		--eval 'PolyML.SaveState.saveModule ("$@", SMLUnit)'
 
 
 bin/smlunit-test-poly.o: $(SMLUNIT_LIB) $(TEST_SRC)
@@ -65,12 +65,8 @@ $(TEST) $(EXAMPLE): %: %.o
 
 
 .PHONY: install-nodoc
-install-nodoc: smlunit-lib-nodoc
-	@install -D -m 644 -t $(PREFIX)/$(LIBDIR) $(SMLUNIT_LIB)
-	@echo "================================================================"
-	@echo "smlunit-lib has been installed to:"
-	@echo "\t$(PREFIX)/$(LIBDIR)/$(SMLUNIT_LIB)"
-	@echo "================================================================"
+install-nodoc: $(SMLUNIT_LIB)
+	@install -D -m 644 -t $(LIBDIR)/smlunit-lib $(SMLUNIT_LIB)
 
 
 .PHONY: install

--- a/Makefile.smlnj
+++ b/Makefile.smlnj
@@ -21,40 +21,55 @@ MLDEPENDS_FLAGS   := -n
 SML_DULIST        :=
 
 PREFIX            := /usr/local/sml
-LIBDIR            := lib/smlunit-lib.cm
+LIBDIR            := $(PREFIX)/lib
 DOCDIR            := $(PREFIX)/doc
 
-SOURCES_CM        := smlunit-lib.cm \
-                     src/test/sources.cm \
-                     basis/test/sources.cm \
-                     example/sources.cm
-
-DEPENDS           := $(SOURCES_CM:.cm=.d)
+SMLUNIT_LIB       := .cm/$(CM_SUFFIX)/smlunit-lib.cm
+SMLUNIT_LIB_COMPAT := \
+                     .cm/$(CM_SUFFIX)/smlunitlib.cm
 
 TEST_TARGET       := bin/TestMain.$(HEAP_SUFFIX)
+
 BASIS_TEST_TARGET := bin/BasisTestMain.$(HEAP_SUFFIX)
+
 EXAMPLE_TARGET    := bin/ExampleMain.$(HEAP_SUFFIX)
+
+SMLUNIT_CM        := smlunit-lib.cm
+
+TEST_CM           := src/test/sources.cm
+
+BASIS_TEST_CM     := basis/test/sources.cm
+
+EXAMPLE_CM        := example/sources.cm
+
+DEPENDS           := $(SMLUNIT_CM).d
+
+TEST_DEPENDS      := $(TEST_CM:.cm=.cm.d) \
+                     $(BASIS_TEST_CM:.cm=.cm.d)
+
+EXAMPLE_DEPENDS   := $(EXAMPLE_CM:.cm=.cm.d)
+
 
 all: smlunit-lib
 
 
 .PHONY: smlunit-lib-nodoc
-smlunit-lib-nodoc: .cm/$(CM_SUFFIX)/smlunit-lib.cm
+smlunit-lib-nodoc: $(SMLUNIT_LIB) $(SMLUNIT_LIB_COMPAT)
 
 
 .PHONY: smlunit-lib
 smlunit-lib: smlunit-lib-nodoc doc
 
 
-.cm/$(CM_SUFFIX)/%.cm: %.cm
+$(SMLUNIT_LIB) $(SMLUNIT_LIB_COMPAT): .cm/$(CM_SUFFIX)/%.cm: %.cm
 	@echo "  [SMLNJ] $@"
 	@echo 'CM.stabilize true "$<";' | $(SML) $(SML_BITMODE) $(SML_DULIST)
 
 
-$(DEPENDS): %.d: %.cm
+$(DEPENDS) $(TEST_DEPENDS) $(EXAMPLE_DEPENDS): %.cm.d: %.cm
 	@echo "  [GEN] $@"
-	@touch $@
-	$(MLDEPENDS) $(MLDEPENDS_FLAGS) $(SML_BITMODE) $(SML_DULIST) -f $@ $< $(dir $<).cm/$(CM_SUFFIX)
+	@truncate --size 0 $@
+	@$(MLDEPENDS) $(MLDEPENDS_FLAGS) $(SML_BITMODE) $(SML_DULIST) -f $@ $< $(dir $<).cm/$(CM_SUFFIX)
 	@sed -i -e "s|^\([^#][^:]\+\):|\1 $@:|" $@
 
 
@@ -62,17 +77,25 @@ ifeq (,$(findstring clean,$(MAKECMDGOALS)))
   include $(DEPENDS)
 endif
 
+
+ifeq (test,$(findstring test,$(MAKECMDGOALS)))
+  include $(TEST_DEPENDS)
+endif
+
+
+ifeq (example,$(findstring example,$(MAKECMDGOALS)))
+  include $(EXAMPLE_DEPENDS)
+endif
+
+
 .PHONY: install-nodoc
 install-nodoc: smlunit-lib-nodoc
-	@install -d $(PREFIX)/$(LIBDIR)
-	@cp -R .cm $(PREFIX)/$(LIBDIR)/
+	@install -D -m 644 -t $(LIBDIR)/smlunit-lib.cm/.cm/$(CM_SUFFIX)  $(SMLUNIT_LIB)
+	@install -D -m 644 -t $(LIBDIR)/smlunitlib.cm/.cm/$(CM_SUFFIX)   $(SMLUNIT_LIB_COMPAT)
 	@echo "================================================================"
-	@echo "smlunit-lib has been installed to:"
-	@echo "\t$(PREFIX)/$(LIBDIR)"
-	@echo "Next, add an entry to your pathconfig (e.g. ~/.smlnj-pathconfig) such like:"
-	@echo "\tsmlunit-lib.cm $(PREFIX)/$(LIBDIR)"
-	@echo "Then you can load the library like"
-	@echo "\t- CM.make \"$$/smlunit-lib.cm\";"
+	@echo "Add an entry to your pathconfig (e.g. ~/.smlnj-pathconfig):"
+	@echo "\tsmlunit-lib.cm $(LIBDIR)/smlunit-lib.cm"
+	@echo "\tsmlunitlib.cm  $(LIBDIR)/smlunitlib.cm"
 	@echo "================================================================"
 
 
@@ -98,14 +121,16 @@ install-doc: doc
 	@echo "================================================================"
 
 
-$(TEST_TARGET): src/test/.cm/$(CM_SUFFIX)
-	@mkdir -p bin
-	$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) $(<:%/.cm/$(CM_SUFFIX)=%/sources.cm) TestMain.main $(basename $@)
+$(TEST_TARGET): $(TEST_CM)
+	@echo "  [SMLNJ] $@"
+	@install -d $(dir $@)
+	@$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) $< TestMain.main $(basename $@)
 
 
-$(BASIS_TEST_TARGET): basis/test/.cm/$(CM_SUFFIX)
-	@mkdir -p bin
-	$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) $(<:%/.cm/$(CM_SUFFIX)=%/sources.cm) TestMain.main $(basename $@)
+$(BASIS_TEST_TARGET): $(BASIS_TEST_CM)
+	@echo "  [SMLNJ] $@"
+	@install -d $(dir $@)
+	@$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) $< TestMain.main $(basename $@)
 
 
 .PHONY: test
@@ -115,8 +140,9 @@ test: $(TEST_TARGET) $(BASIS_TEST_TARGET)
 
 
 $(EXAMPLE_TARGET): example/.cm/$(CM_SUFFIX)
+	@echo "  [SMLNJ] $@"
 	@mkdir -p bin
-	$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) $(patsubst %/.cm/amd64-unix,%/sources.cm,$<) Main.main $(basename $@)
+	@$(MLBUILD) $(SML_BITMODE) $(SML_DULIST) $(MLBUILD_FLAGS) $(patsubst %/.cm/amd64-unix,%/sources.cm,$<) Main.main $(basename $@)
 
 
 .PHONY: example
@@ -126,14 +152,18 @@ example: $(EXAMPLE_TARGET)
 
 .PHONY: clean
 clean:
+	-$(RM) $(SMLUNIT_LIB)
+	-$(RM) $(SMLUNIT_LIB_COMPAT)
 	-$(RM) $(DEPENDS)
+	-$(RM) $(TEST_TARGET)
+	-$(RM) $(BASIS_TEST_TARGET)
+	-$(RM) $(TEST_DEPENDS)
+	-$(RM) $(EXAMPLE_TARGET)
+	-$(RM) $(EXAMPLE_DEPENDS)
 	-$(RM) -r doc/api
 	-$(RM) -r .cm
 	-$(RM) -r src/.cm
 	-$(RM) -r src/main/.cm
 	-$(RM) -r src/test/.cm
-	-$(RM) $(TEST_TARGET)
 	-$(RM) -r basis/test/.cm
-	-$(RM) $(BASIS_TEST_TARGET)
 	-$(RM) -r example/.cm
-	-$(RM) $(EXAMPLE_TARGET)

--- a/Makefile.smlnj
+++ b/Makefile.smlnj
@@ -22,7 +22,7 @@ SML_DULIST        :=
 
 PREFIX            := /usr/local/sml
 LIBDIR            := lib/smlunit-lib.cm
-DOCDIR            := doc/smlunit-lib
+DOCDIR            := $(PREFIX)/doc
 
 SOURCES_CM        := smlunit-lib.cm \
                      src/test/sources.cm \
@@ -83,18 +83,18 @@ install: install-doc install-nodoc
 .PHONY: doc
 doc:
 	@echo "  [SMLDoc]"
-	@$(RM) -r $(DOCDIR)
-	@install -d $(DOCDIR)
-	@$(SMLDOC) -c UTF-8 -a $(SMLDOC_ARGFILE) -d "$(DOCDIR)"
+	@$(RM) -r doc/api
+	@install -d doc/api
+	@$(SMLDOC) -c UTF-8 -a $(SMLDOC_ARGFILE) -d doc/api
 
 
 .PHONY: install-doc
 install-doc: doc
-	@install -d $(PREFIX)/$(DOCDIR)
-	@cp -prT $(DOCDIR) $(PREFIX)/$(DOCDIR)
+	@install -d $(DOCDIR)
+	@cp -prT doc $(DOCDIR)/smlunit-lib
 	@echo "================================================================"
 	@echo "Generated API Documents of SMLUnit"
-	@echo "\t$(PREFIX)/$(DOCDIR)"
+	@echo "\t$(DOCDIR)/smlunit-lib"
 	@echo "================================================================"
 
 
@@ -127,7 +127,7 @@ example: $(EXAMPLE_TARGET)
 .PHONY: clean
 clean:
 	-$(RM) $(DEPENDS)
-	-$(RM) -r $(DOCDIR)
+	-$(RM) -r doc/api
 	-$(RM) -r .cm
 	-$(RM) -r src/.cm
 	-$(RM) -r src/main/.cm

--- a/readme.md
+++ b/readme.md
@@ -64,10 +64,11 @@ To install SMLUnit for [SML/NJ], run `make install` with `Makefile.smlnj`:
 $ make -f Makefile.smlnj install
 ```
 
-To specify the directory to install to, run `make` with the variable `PREFIX`:
+Above command install SMLUnit to `/usr/local/sml`.
+This install location can be set with `PREFIX` variable like:
 
 ```sh
-$ make -f Makefile.smlnj install PREFIX=~/.sml/smlnj
+$ make -f Makefile.smlnj install PREFIX=~/.sml/smlnj/110.99
 ```
 
 The `install` target uses [SMLDoc] to generate the documentations for SMLUnit.
@@ -92,7 +93,7 @@ $ echo 'smlunit-lib.cm PREFIX/lib/smlunit-lib.cm' >> ~/.smlnj-pathconfig
 
 #### Test
 
-To run SMLUnit unit tests, run the `test` target:
+To run unit tests, run the `test` target:
 
 ```sh
 $ make -f Makefile.smlnj test
@@ -134,14 +135,13 @@ If you do not need to generate documentation, run the `install-nodoc` target.
 $ make -f Makefile.mlton install-nodoc
 ```
 
-After running the `install` target, add an entry for `SMLUNIT_LIB` to your mlb path mapping file:
+After running the `install` target, add an entry for `SMLUNIT_LIB` to your mlb path mapping file to complete the installation.
 
 ```sh
 $ echo 'SMLUNIT_LIB /path/to/$PREFIX' >> /path/to/mlb-path-map
 ```
 
-
-For using SMLUnit, refer to `$(SMLUNIT_LIB)/smlunit-lib.mlb` from your mlbasis file.
+For using SMLUnit, refer to `$(SMLUNIT_LIB)/smlunit-lib.mlb` from your MLB file.
 
 ```
 $(SML_LIB)/basis/basis.mlb
@@ -153,7 +153,7 @@ $(SMLUNIT_LIB)/smlunit-lib.mlb
 
 #### Test
 
-To run SMLUnit unit tests, run the `test` target:
+To run unit tests, run the `test` target:
 
 ```sh
 $ make -f Makefile.mlton test
@@ -164,7 +164,7 @@ Depending on the test case, it will fails.
 
 #### Examples
 
-To run the example program, run `example` target:
+To run the example program, run the `example` target:
 
 ```sh
 $ make -f Makefile.smlnj example
@@ -176,13 +176,14 @@ $ make -f Makefile.smlnj example
 
 #### Install
 
-To install SMLUnit for [Poly/ML], run the `install` target.
+To install SMLUnit for [Poly/ML], run `make install` with `Makefile.polyml`.
 
 ```sh
 $ make -f Makefile.polyml install
 ```
 
-To specify the directory to install to, run `make` with the variable `PREFIX`:
+Above command install SMLUnit to `/usr/local/polyml`.
+This install location can be set with `PREFIX` variable like:
 
 ```sh
 $ make -f Makefile.polyml PREFIX=~/.sml/polyml/5.8.1 install
@@ -212,7 +213,7 @@ val it = (): unit
 
 #### Test
 
-To run SMLUnit unit tests, run the `test` target:
+To run unit tests, run the `test` target:
 
 ```sh
 $ make -f Makefile.polyml test
@@ -226,17 +227,9 @@ Depending on the test case, it will fails.
 To run the example program, run the `example` target:
 
 ```sh
-
 $ make -f Makefile.polyml example
-  [POLYML] bin/smlunit-example-poly.o
-..
-  [POLYC] bin/smlunit-example-poly
-bin/smlunit-example-poly
-.....
-tests = 5, failures = 0, errors = 0
-Failures:
-Errors:
 ```
+
 
 [SML/NJ]: https://www.smlnj.org/ "Standard ML of New Jersey"
 

--- a/src/smldoc.cfg
+++ b/src/smldoc.cfg
@@ -1,4 +1,4 @@
---directory=../doc/smlunit-lib
+--directory=../doc/api
 --hidebysig
 --verbose
 --author


### PR DESCRIPTION
Improve Makefiles for SML/NJ, MLton and Poly/ML.

# Common

- Improve Readme.md
- Change the path to install the documentation to doc/api.

# SML/NJ

- Track dependencies of tests and examples correctly.

# MLton

- Type check smlunit-lib.mlb and smlunitlib.mlb
- Track dependencies of tests and examples correctly.
